### PR TITLE
fix dbschema: add type for edited

### DIFF
--- a/lib/Travelynx/Command/database.pm
+++ b/lib/Travelynx/Command/database.pm
@@ -46,7 +46,7 @@ sub initialize_db {
 				action_id smallint not null,
 				station_id int references stations (id),
 				action_time timestamptz not null,
-				edited not null,
+				edited smallint not null,
 				train_type varchar(16),
 				train_line varchar(16),
 				train_no varchar(16),


### PR DESCRIPTION
```
DBD::Pg::db do failed: FEHLER:  Syntaxfehler bei �not�
LINE 28:     edited not null,
                    ^ at lib/Travelynx/Command/database.pm line 21.
```