### PR TITLE
fix excess column in history statistics

### DIFF
--- a/templates/_history_stats.html.ep
+++ b/templates/_history_stats.html.ep
@@ -39,7 +39,7 @@
 			<tr>
 				<th scope="row">Fahrtzeit</th>
 				<td><%= $stats->{min_travel_real_strf} %> Stunden
-					(nach Fahrplan: <%= $stats->{min_travel_sched_strf} %>)<td>
+					(nach Fahrplan: <%= $stats->{min_travel_sched_strf} %>)</td>
 			</tr>
 			<tr>
 				<th scope="row">Wartezeit (nur Umstiege)</th>


### PR DESCRIPTION
This pull request fixes a typo in the history stats template.

Previously, the HTML parser would close the travel time table data cell element but also create a new, empty table data cell in the process. This empty excess cell would create a new column in the table, causing all other rows to be shifted in the layout.

Now the open travel time data cell element gets closed properly without creating a new cell, allowing the whole table to right align neatly.

![image](https://github.com/derf/travelynx/assets/42888162/258eb207-dcb6-48c3-869f-5a15298bc183)

![image](https://github.com/derf/travelynx/assets/42888162/6340b157-bb06-479e-a5e8-adba709039f2)

Please note that I have not been able to test this locally as I'm lacking a proper development setup