### PR TITLE
Add version string to default template parameters

### DIFF
--- a/lib/Travelynx.pm
+++ b/lib/Travelynx.pm
@@ -72,6 +72,7 @@ sub startup {
 	}
 
 	chomp $self->config->{version};
+	$self->defaults(version => $self->config->{version} // 'UNKNOWN');
 
 	$self->plugin(
 		authentication => {

--- a/lib/Travelynx/Controller/Profile.pm
+++ b/lib/Travelynx/Controller/Profile.pm
@@ -207,7 +207,6 @@ sub profile {
 		journey            => $status,
 		journey_visibility => $visibility,
 		journeys           => [@journeys],
-		version            => $self->app->config->{version} // 'UNKNOWN',
 	);
 }
 

--- a/lib/Travelynx/Controller/Static.pm
+++ b/lib/Travelynx/Controller/Static.pm
@@ -8,15 +8,13 @@ use Mojo::Base 'Mojolicious::Controller';
 sub about {
 	my ($self) = @_;
 
-	$self->render( 'about',
-		version => $self->app->config->{version} // 'UNKNOWN' );
+	$self->render('about');
 }
 
 sub changelog {
 	my ($self) = @_;
 
-	$self->render( 'changelog',
-		version => $self->app->config->{version} // 'UNKNOWN' );
+	$self->render('changelog');
 }
 
 sub imprint {

--- a/lib/Travelynx/Controller/Traveling.pm
+++ b/lib/Travelynx/Controller/Traveling.pm
@@ -398,8 +398,6 @@ sub homepage {
 						my ( $connecting_trains, $transit_fyi ) = @_;
 						$self->render(
 							'landingpage',
-							version => $self->app->config->{version}
-							  // 'UNKNOWN',
 							user_status        => $status,
 							journey_visibility => $journey_visibility,
 							connections        => $connecting_trains,
@@ -412,8 +410,6 @@ sub homepage {
 					sub {
 						$self->render(
 							'landingpage',
-							version => $self->app->config->{version}
-							  // 'UNKNOWN',
 							user_status        => $status,
 							journey_visibility => $journey_visibility,
 						);
@@ -426,7 +422,6 @@ sub homepage {
 			else {
 				$self->render(
 					'landingpage',
-					version     => $self->app->config->{version} // 'UNKNOWN',
 					user_status => $status,
 					journey_visibility => $journey_visibility,
 				);
@@ -441,7 +436,6 @@ sub homepage {
 		}
 		$self->render(
 			'landingpage',
-			version           => $self->app->config->{version} // 'UNKNOWN',
 			user_status       => $status,
 			recent_targets    => \@recent_targets,
 			with_autocomplete => 1,
@@ -452,7 +446,6 @@ sub homepage {
 	else {
 		$self->render(
 			'landingpage',
-			version => $self->app->config->{version} // 'UNKNOWN',
 			intro   => 1
 		);
 	}
@@ -899,8 +892,6 @@ sub station {
 							can_check_out    => $can_check_out,
 							connections      => $connecting_trains,
 							title   => "travelynx: $status->{station_name}",
-							version => $self->app->config->{version}
-							  // 'UNKNOWN',
 						);
 					}
 				)->catch(
@@ -915,8 +906,6 @@ sub station {
 							user_status      => $user_status,
 							can_check_out    => $can_check_out,
 							title   => "travelynx: $status->{station_name}",
-							version => $self->app->config->{version}
-							  // 'UNKNOWN',
 						);
 					}
 				)->wait;
@@ -932,7 +921,6 @@ sub station {
 					user_status      => $user_status,
 					can_check_out    => $can_check_out,
 					title            => "travelynx: $status->{station_name}",
-					version => $self->app->config->{version} // 'UNKNOWN',
 				);
 			}
 		}
@@ -942,7 +930,6 @@ sub station {
 			if ( ref($err) eq 'HASH' ) {
 				$self->render(
 					'landingpage',
-					version => $self->app->config->{version} // 'UNKNOWN',
 					with_autocomplete => 1,
 					with_geolocation  => 1,
 					error             => $err->{errstr},
@@ -1296,7 +1283,6 @@ sub year_in_review {
 
 	$self->render(
 		'year_in_review',
-		version => $self->app->config->{version} // 'UNKNOWN',
 		title   => "travelynx Jahresrückblick $year",
 		year    => $year,
 		stats   => $stats,


### PR DESCRIPTION
Some pages don't display the version string correctly in the page footer. For example, `/login` on travelynx.de currently shows "travelynx v???" in the page footer:

![screenshot](https://github.com/derf/travelynx/assets/33266253/4858a6a9-148f-4312-bd84-5e60d79b9a1e)

The template for the login page includes the `_footer` template fragment, and explicitly passes through the `version` parameter from the request stash:
https://github.com/derf/travelynx/blob/0516344ac09214ca8dde0fe0d9fa7b7832213ef0/templates/login.html.ep#L101

However, when this template is rendered in this request handler, the `version` parameter is never explicitly provided:
https://github.com/derf/travelynx/blob/0516344ac09214ca8dde0fe0d9fa7b7832213ef0/lib/Travelynx/Controller/Account.pm#L235-L238

As there is no default value set in the request stash, this results in the placeholder text "???" being used instead:
https://github.com/derf/travelynx/blob/0516344ac09214ca8dde0fe0d9fa7b7832213ef0/templates/_footer.html.ep#L3

This PR sets a default value for the `version` field of the request stash, so that this parameter is automatically set when rendering pages. As this parameter no longer needs to be passed explicitly, this PR also removes all occurrences of the explicit `version` parameter in existing page handlers.