### PR TITLE
Checkin: Use correct visibility when pushing to Träwelling

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Birte Kristina Friesel <derf@finalrewind.org>

--- a/lib/Travelynx/Helper/Traewelling.pm
+++ b/lib/Travelynx/Helper/Traewelling.pm
@@ -1,6 +1,7 @@
 package Travelynx::Helper::Traewelling;
 
 # Copyright (C) 2020-2023 Birte Kristina Friesel
+# Copyright (C) 2023 networkException <git@nwex.de>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -322,6 +323,20 @@ sub logout_p {
 	return $promise;
 }
 
+sub convert_travelynx_to_traewelling_visibility {
+	my ( $travelynx_visibility ) = @_;
+
+	my %visibilities = (
+		100 => 0, # public      => StatusVisibility::PUBLIC
+		80  => 4, # travelynx   => StatusVisibility::AUTHENTICATED (only visible for logged in users)
+		60  => 2, # followers   => StatusVisibility::FOLLOWERS
+		30  => 3, # unlisted    => StatusVisibility::PRIVATE (there is no träwelling equivalent to unlisted, their StatusVisibility::UNLISTED shows the journey on the profile)
+		10  => 3, # private     => StatusVisibility::PRIVATE
+	);
+
+	return $visibilities{$travelynx_visibility};
+}
+
 sub checkin_p {
 	my ( $self, %opt ) = @_;
 
@@ -352,6 +367,7 @@ sub checkin_p {
 		arrival     => $arrival_ts,
 		toot        => $opt{data}{toot}  ? \1 : \0,
 		tweet       => $opt{data}{tweet} ? \1 : \0,
+		visibility  => convert_travelynx_to_traewelling_visibility($opt{visibility})
 	};
 
 	if ( $opt{user_data}{comment} ) {

--- a/lib/Travelynx/Helper/Traewelling.pm
+++ b/lib/Travelynx/Helper/Traewelling.pm
@@ -324,14 +324,27 @@ sub logout_p {
 }
 
 sub convert_travelynx_to_traewelling_visibility {
-	my ( $travelynx_visibility ) = @_;
+	my ($travelynx_visibility) = @_;
 
 	my %visibilities = (
-		100 => 0, # public      => StatusVisibility::PUBLIC
-		80  => 4, # travelynx   => StatusVisibility::AUTHENTICATED (only visible for logged in users)
-		60  => 2, # followers   => StatusVisibility::FOLLOWERS
-		30  => 3, # unlisted    => StatusVisibility::PRIVATE (there is no träwelling equivalent to unlisted, their StatusVisibility::UNLISTED shows the journey on the profile)
-		10  => 3, # private     => StatusVisibility::PRIVATE
+
+		# public    => StatusVisibility::PUBLIC
+		100 => 0,
+
+		# travelynx => StatusVisibility::AUTHENTICATED
+		# (only visible for logged in users)
+		80 => 4,
+
+		# followers => StatusVisibility::FOLLOWERS
+		60 => 2,
+
+		# unlisted  => StatusVisibility::PRIVATE
+		# (there is no träwelling equivalent to unlisted, their
+		# StatusVisibility::UNLISTED shows the journey on the profile)
+		30 => 3,
+
+		# private   => StatusVisibility::PRIVATE
+		10 => 3,
 	);
 
 	return $visibilities{$travelynx_visibility};
@@ -367,7 +380,8 @@ sub checkin_p {
 		arrival     => $arrival_ts,
 		toot        => $opt{data}{toot}  ? \1 : \0,
 		tweet       => $opt{data}{tweet} ? \1 : \0,
-		visibility  => convert_travelynx_to_traewelling_visibility($opt{visibility})
+		visibility  =>
+		  convert_travelynx_to_traewelling_visibility( $opt{visibility} )
 	};
 
 	if ( $opt{user_data}{comment} ) {

--- a/lib/Travelynx/Model/Traewelling.pm
+++ b/lib/Travelynx/Model/Traewelling.pm
@@ -213,18 +213,17 @@ sub get_pushable_accounts {
 	my $res = $self->{pg}->db->query(
 		qq{select t.user_id as uid, t.token as token, t.data as data,
 			i.user_data as user_data,
-			i.checkin_station_id as dep_eva, i.checkout_station_id as arr_eva,
+			i.dep_eva as dep_eva, i.arr_eva as arr_eva,
 			i.data as journey_data, i.train_type as train_type,
 			i.train_line as train_line, i.train_no as train_no,
-			extract(epoch from i.checkin_time) as checkin_ts,
-			extract(epoch from i.sched_departure) as dep_ts,
-			extract(epoch from i.sched_arrival) as arr_ts,
-			i_str.effective_visibility as visibility
+			i.checkin_ts as checkin_ts,
+			i.sched_dep_ts as dep_ts,
+			i.sched_arr_ts as arr_ts,
+			i.effective_visibility as visibility
 			from traewelling as t
-			join in_transit as i on t.user_id = i.user_id
-			join in_transit_str as i_str on t.user_id = i_str.user_id
+			join in_transit_str as i on t.user_id = i.user_id
 			where t.push_sync = True
-			and i.checkout_station_id is not null
+			and i.arr_eva is not null
 			and i.cancelled = False
 		}
 	);

--- a/lib/Travelynx/Model/Traewelling.pm
+++ b/lib/Travelynx/Model/Traewelling.pm
@@ -218,9 +218,11 @@ sub get_pushable_accounts {
 			i.train_line as train_line, i.train_no as train_no,
 			extract(epoch from i.checkin_time) as checkin_ts,
 			extract(epoch from i.sched_departure) as dep_ts,
-			extract(epoch from i.sched_arrival) as arr_ts
+			extract(epoch from i.sched_arrival) as arr_ts,
+			i_str.effective_visibility as visibility
 			from traewelling as t
 			join in_transit as i on t.user_id = i.user_id
+			join in_transit_str as i_str on t.user_id = i_str.user_id
 			where t.push_sync = True
 			and i.checkout_station_id is not null
 			and i.cancelled = False

--- a/templates/traewelling.html.ep
+++ b/templates/traewelling.html.ep
@@ -191,8 +191,8 @@
 				<p>Die Synchronisierung erfolgt spätestens drei Minuten nach der
 					Zielwahl. Beachte, dass die Synchronisierung travelynx
 					→ Träwelling unabhängig von der eingestellten Sichtbarkeit
-					des Checkins erfolgt und Träwelling-Sichtbarkeiten
-					derzeit ebenfalls nicht von travelynx übernommen werden.
+					des Checkins erfolgt. travelynx reicht die Sichtbarkeit
+					aber an Träwelling weiter.
 					Träwelling-Checkins können von travelynx aktuell nicht
 					rückgängig gemacht werden. Eine nachträgliche Änderung der
 					Zielstation wird nicht übernommen. Mastodon und Twitter beziehen
@@ -211,7 +211,8 @@
 					Falls du gerade in einen Zug eingecheckt bist, wird dieser von
 					travelynx übernommen.  Träwelling-Checkins in Nahverkehrsmittel
 					und Züge außerhalb des deutschen Schienennetzes werden nicht
-					unterstützt.</p>
+					unterstützt. Die Sichtbarkeit von Träwelling-Checkins wird
+					derzeit von travelynx nicht berücksichtigt.</p>
 			</div>
 		</div>
 		<div class="row hide-on-small-only">


### PR DESCRIPTION
This pull request implements Travelynx to Träwelling visibility conversion to include the correct visibility when initially pushing a checkin.