### PR TITLE
More rainbow!!

### DIFF
--- a/lib/Travelynx/Controller/Traveling.pm
+++ b/lib/Travelynx/Controller/Traveling.pm
@@ -1479,7 +1479,8 @@ sub yearly_history {
 		uid           => $self->current_user->{id},
 		after         => $interval_start,
 		before        => $interval_end,
-		with_datetime => 1
+		with_datetime => 1,
+		with_pride    => 1,
 	);
 
 	if ( $filter and $filter eq 'single' ) {
@@ -1560,7 +1561,8 @@ sub monthly_history {
 		uid           => $self->current_user->{id},
 		after         => $interval_start,
 		before        => $interval_end,
-		with_datetime => 1
+		with_datetime => 1,
+		with_pride    => 1,
 	);
 
 	if ( not @journeys ) {
@@ -1623,6 +1625,7 @@ sub journey_details {
 		with_datetime   => 1,
 		with_polyline   => 1,
 		with_visibility => 1,
+		with_pride    	=> 1,
 	);
 
 	if ($journey) {

--- a/lib/Travelynx/Model/Journeys.pm
+++ b/lib/Travelynx/Model/Journeys.pm
@@ -611,6 +611,14 @@ sub get {
 			$ref->{polyline} = $entry->{polyline};
 		}
 
+		if ( $opt{with_pride} ) {
+			for my $wagongroup ( @{ $ref->{user_data}{wagongroups} } ) {
+				if ( $wagongroup->{name} eq 'ICE0304' ) {
+					$ref->{wagonorder_pride} = 1;
+				}
+			}
+		}
+
 		if ( $opt{with_datetime} ) {
 			$ref->{checkin} = epoch_to_dt( $ref->{checkin_ts} );
 			$ref->{sched_departure}

--- a/templates/_checked_in.html.ep
+++ b/templates/_checked_in.html.ep
@@ -7,12 +7,7 @@
 				<span class="card-title center-align">Ziel wählen</span>
 			% }
 			<span class="card-title center-align">
-					% if ($journey->{train_line}) {
-						<b><%= $journey->{train_type} %> <%= $journey->{train_line} %></b> <%= $journey->{train_no} %>
-					% }
-					% else {
-						<%= $journey->{train_type} %> <%= $journey->{train_no} %>
-					% }
+				<%= include '_format_train', journey => $journey %>
 			</span>
 			% if ($journey->{comment}) {
 				<p><%= $journey->{comment} %></p>

--- a/templates/_history_trains.html.ep
+++ b/templates/_history_trains.html.ep
@@ -17,7 +17,14 @@
 					% }
 					<tr>
 						<td><%= $travel->{sched_departure}->strftime($date_format) %></td>
-						<td><a href="<%= $detail_link %>"><%= $travel->{type} %> <%= $travel->{line} // $travel->{no} %></a></td>
+						<td>
+							<a href="<%= $detail_link %>">
+								<%= $travel->{type} %> <%= $travel->{line} // $travel->{no} %>
+								% if ($travel->{wagonorder_pride}) {
+									🏳️‍🌈
+								% }
+							</a>
+						</td>
 						<td>
 						<a href="<%= $detail_link %>" class="unmarked">
 						% if (param('cancelled')) {

--- a/templates/_wagons.html.ep
+++ b/templates/_wagons.html.ep
@@ -1,4 +1,7 @@
 % for my $wagongroup (@{$wagongroups // []}) {
+	% if ($wagongroup->{name} eq 'ICE0304') {
+		🏳️‍🌈
+	% }
 	<%= $wagongroup->{name} %>
 	% my ($wagon_number) = ($wagongroup->{name} =~ m{ ^ ICE 0* (\d+) $ }x);
 	% if ($wagon_number and my $group_name = app->ice_name->{$wagon_number}) {

--- a/templates/journey.html.ep
+++ b/templates/journey.html.ep
@@ -71,6 +71,9 @@
 				<tr>
 					<th scope="row">Fahrt</th>
 					<td>
+						% if ($journey->{wagonorder_pride}) {
+							🏳️‍🌈
+						% }
 						<%= $journey->{type} %> <%= $journey->{no} %>
 						% if ($journey->{line}) {
 							(Linie <%= $journey->{line} %>)

--- a/templates/landingpage.html.ep
+++ b/templates/landingpage.html.ep
@@ -76,7 +76,7 @@
 		</div>
 	</div>
 	<h1>Letzte Fahrten</h1>
-	%= include '_history_trains', date_format => '%d.%m', journeys => [journeys->get(uid => current_user->{id}, limit => 5, with_datetime => 1)];
+	%= include '_history_trains', date_format => '%d.%m', journeys => [journeys->get(uid => current_user->{id}, limit => 5, with_datetime => 1, with_pride => 1)];
 % }
 % else {
 	<div class="row">


### PR DESCRIPTION
This pull request adds some logic to determine if a past journey's (from the journeys table) wagongroups included ICE0304, the rainbow ICE.

Based on this (as well as existing in transit data), the web interface has been updated to the rainbow flag in more places:

- In front of the "ICE %number" string in the traveler facing checked in view

  ![image](https://github.com/derf/travelynx/assets/42888162/a2f0b1b6-f83f-4f5c-8ccf-89f22bd3aafa)

- After the "ICE %number" link in monthly and yearly history, as well as recent journeys (the alignment looked odd when the rainbow flag was in front of the link)
  
  ![image](https://github.com/derf/travelynx/assets/42888162/9f1b650a-df02-48d8-aac1-3a98ebac3bb2)

  ![image](https://github.com/derf/travelynx/assets/42888162/6d15b5e4-1d69-4c25-9747-e9021c3c4739)

  ![image](https://github.com/derf/travelynx/assets/42888162/6a70c545-b93c-44dc-ba6d-41c5532aa0cf)

  *(ignore the upper ICE 725, something broke and it's database entry doesn't have wagon groups)*

- In the journey detail view in front of the "ICE %number" string as well as in front of the wagongroup "ICE0304"

  ![image](https://github.com/derf/travelynx/assets/42888162/81847a19-7d49-4033-9fc5-8ffa670456ec)
