### PR TITLE
Neues Layout für die History und ein paar Kleinigkeiten

### DIFF
--- a/lib/Travelynx/Controller/Profile.pm
+++ b/lib/Travelynx/Controller/Profile.pm
@@ -154,6 +154,7 @@ sub profile {
 
 	$self->render(
 		'profile',
+		title => "travelynx: $name",
 		name             => $name,
 		uid              => $user->{id},
 		privacy          => $user,
@@ -313,6 +314,7 @@ sub journey_details {
 	}
 	$self->render(
 		'journey',
+		title => "travelynx: $title",
 		error     => undef,
 		journey   => $journey,
 		with_map  => 1,
@@ -470,6 +472,7 @@ sub user_status {
 		any => {
 			template  => 'user_status',
 			name      => $name,
+			title => "travelynx: $tw_data{title}",
 			privacy   => $user,
 			journey   => $status,
 			twitter   => \%tw_data,

--- a/lib/Travelynx/Controller/Static.pm
+++ b/lib/Travelynx/Controller/Static.pm
@@ -8,25 +8,25 @@ use Mojo::Base 'Mojolicious::Controller';
 sub about {
 	my ($self) = @_;
 
-	$self->render('about');
+	$self->render('about', title => 'Über travelynx');
 }
 
 sub changelog {
 	my ($self) = @_;
 
-	$self->render('changelog');
+	$self->render('changelog',  title => 'travelynx: Changelog');
 }
 
 sub imprint {
 	my ($self) = @_;
 
-	$self->render('imprint');
+	$self->render('imprint',  title => 'travelynx: Impressum');
 }
 
 sub legend {
 	my ($self) = @_;
 
-	$self->render('legend');
+	$self->render('legend', title => 'travelynx: Legende' );
 }
 
 sub offline {

--- a/lib/Travelynx/Controller/Traewelling.pm
+++ b/lib/Travelynx/Controller/Traewelling.pm
@@ -144,6 +144,7 @@ sub settings {
 		$self->param( tweet => 1 );
 	}
 
+	$self->stash ( title => 'travelynx × träwelling' );
 	$self->render(
 		'traewelling',
 		traewelling => $traewelling,

--- a/lib/Travelynx/Controller/Traveling.pm
+++ b/lib/Travelynx/Controller/Traveling.pm
@@ -1185,7 +1185,7 @@ sub cancelled {
 sub history {
 	my ($self) = @_;
 
-	$self->render( template => 'history' );
+	$self->render( template => 'history', title => 'travelynx: History' );
 }
 
 sub commute {
@@ -1293,6 +1293,7 @@ sub commute {
 		journeys_by_month => \%journeys_by_month,
 		count_by_month    => \%count_by_month,
 		total_journeys    => $total,
+		title => 'travelynx: Reisen nach Station',
 		months            => [
 			qw(Januar Februar März April Mai Juni Juli August September Oktober November Dezember)
 		],
@@ -1390,6 +1391,7 @@ sub map_history {
 		template => 'history_map',
 		year     => $year,
 		with_map => 1,
+		title => 'travelynx: Karte',
 		%{$res}
 	);
 }
@@ -1515,7 +1517,7 @@ sub year_in_review {
 
 	$self->render(
 		'year_in_review',
-		title  => "travelynx Jahresrückblick $year",
+		title  => "travelynx: Jahresrückblick $year",
 		year   => $year,
 		stats  => $stats,
 		review => $review,
@@ -1586,6 +1588,7 @@ sub yearly_history {
 		},
 		any => {
 			template    => 'history_by_year',
+			title => "travelynx: $year",
 			journeys    => [@journeys],
 			year        => $year,
 			have_review => $with_review,
@@ -1649,6 +1652,8 @@ sub monthly_history {
 		month => $month
 	);
 
+	my $month_name = $months[ $month - 1 ];
+
 	$self->respond_to(
 		json => {
 			json => {
@@ -1658,10 +1663,11 @@ sub monthly_history {
 		},
 		any => {
 			template   => 'history_by_month',
+			title => "travelynx: $month_name $year",
 			journeys   => [@journeys],
 			year       => $year,
 			month      => $month,
-			month_name => $months[ $month - 1 ],
+			month_name => $month_name,
 			statistics => $stats
 		}
 	);
@@ -1736,6 +1742,9 @@ sub journey_details {
 
 		$self->render(
 			'journey',
+			title =>  sprintf( 'travelynx: %s %s %s am %s',
+				$journey->{type}, $journey->{line} // '', $journey->{no},
+				$journey->{sched_arrival}->strftime('%d.%m.%Y, %H:%M') ),
 			error              => undef,
 			journey            => $journey,
 			journey_visibility => $visibility,

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -7,6 +7,10 @@
 	cursor: pointer;
 }
 
+.navbar-fixed {
+	z-index: 1001;
+}
+
 .brand-logo span {
 	transition: color 1s;
 }

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -72,17 +72,14 @@ ul.suggestions {
 	}
 }
 
-
-.departures li {
+.collection.departures li, .collection.history li {
 	transition: background .3s;
 	display: grid;
-	grid-template-columns: 10ch 10ch 1fr;
-	align-items: center;
-	&:not(#now):hover, &:focus-within {
+	&:not(#now,.history-date-change ):hover, &:focus-within {
 		background-color: $departures-highlight-color;
 		outline: 2px solid $link-color;
 	}
- 	&.cancelled {
+	&.cancelled {
 		background-color: $departures-cancelled-color;
 		font-style: italic;
 		.dep-line {
@@ -95,6 +92,11 @@ ul.suggestions {
 		  font-style: normal;
 		}
 	}
+}
+
+.collection.departures li {
+	grid-template-columns: 10ch 10ch 1fr;
+	align-items: center;
 	&#now {
 		background-color: $departures-highlight-color;
 		padding: 2rem 20px;
@@ -102,6 +104,36 @@ ul.suggestions {
 		strong {
 			font-weight: bold;
 		}
+	}
+}
+.collection.history li {
+	display: grid;
+	grid-template-columns: 10ch 1fr;
+	grid-template-rows: 1fr;
+	a:first-child {
+		grid-row: 1 / span 3;
+		align-self: center;
+		text-align: center;
+		display: flex;
+	}
+	.origin, .destination {
+		grid-column: 2;
+		strong {
+			font-weight: 600;
+		}
+	}
+	.destination::before {
+		content: ' ';
+		display: block;
+		border-left: 2px dotted $off-black;
+		height: 1rem;
+		position: absolute;
+		margin-left: calc( 0.5rem - 1px );
+		margin-top: -0.5rem;
+	}
+	&.history-date-change {
+		display: block;
+		font-weight: bold;
 	}
 }
 
@@ -204,12 +236,12 @@ ul.suggestions {
 
 
 @media screen and (max-width: 600px) {
-	.departures li {
+	.collection.departures li {
 		grid-template-columns: 10ch 1fr;
 		.dep-line, .dep-time, .connect-platform-wrapper {
 			grid-column: 1;
 			text-align: center;
-		} 
+		}
 		.dep-dest {
 			grid-column: 2;
 			grid-row: 1 / span 2;

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -122,7 +122,7 @@ ul.suggestions {
 		}
 	}
 }
-.departures .dep-line {
+.dep-line {
 	text-align: center;
 	padding: .2rem;
 	color: white;
@@ -135,7 +135,7 @@ ul.suggestions {
 	width: fit-content;
 	min-width: 6ch;
 	margin: 0 auto;
-	
+
 	&.Bus, &.RUF, &.AST {
 		background-color: #a3167e;
 		border-radius: 5rem;

--- a/templates/_checked_in.html.ep
+++ b/templates/_checked_in.html.ep
@@ -7,12 +7,7 @@
 				<span class="card-title center-align">Ziel wählen</span>
 			% }
 			<span class="card-title center-align">
-					% if ($journey->{train_line}) {
-						<b><%= $journey->{train_type} %> <%= $journey->{train_line} %></b> <%= $journey->{train_no} %>
-					% }
-					% else {
-						<%= $journey->{train_type} %> <%= $journey->{train_no} %>
-					% }
+				%= include '_format_train', journey => $journey
 			</span>
 			% if ($journey->{comment}) {
 				<p><%= $journey->{comment} %></p>

--- a/templates/_checked_in.html.ep
+++ b/templates/_checked_in.html.ep
@@ -331,13 +331,14 @@
 				% }
 			</div>
 			<div class="card-action">
+				% my $url = 'https://bahn.expert/details/';
 				% if ($journey->{train_id} =~ m{[|]}) {
-					&nbsp;
+					% $url =  $url .  '/' . $journey->{sched_departure}->epoch . '000?jid=' . $journey->{train_id};
 				% }
 				% else {
-					% my $url = 'https://bahn.expert/details/' . $journey->{train_type} . ' ' . $journey->{train_no} . '/' . DateTime->now(time_zone => 'Europe/Berlin')->epoch . '000';
-					<a style="margin-right: 0;" href="<%= $url %>" aria-label="Zuglauf"><i class="material-icons left">timeline</i> Zuglauf</a>
+					% $url = $url . $journey->{train_type} . ' ' . $journey->{train_no} . '/' . $journey->{sched_departure}->epoch . '000?station=' . $journey->{dep_eva};
 				% }
+				<a style="margin-right: 0;" href="<%= $url %>"><i class="material-icons left" aria-hidden="true">timeline</i> Zuglauf</a>
 				% if ($journey->{extra_data}{trip_id}) {
 					<a class="right" style="margin-right: 0;" href="https://dbf.finalrewind.org/map/<%= $journey->{extra_data}{trip_id} %>/<%= $journey->{train_line} || 0 %>?from=<%= $journey->{dep_name} %>&amp;to=<%= $journey->{arr_name} %>&amp;dark=<%= (session('theme') and session('theme') eq 'dark') ? 1 : 0 %>"><i class="material-icons left" aria-hidden="true">map</i> Karte</a>
 				% }

--- a/templates/_checked_out.html.ep
+++ b/templates/_checked_out.html.ep
@@ -1,7 +1,8 @@
 <div class="card">
 	<div class="card-content">
 		<span class="card-title">Ausgecheckt</span>
-		<p>Aus <%= $journey->{train_type} %> <%= $journey->{train_no} %>
+		<p>Aus
+			%= include '_format_train', journey => $journey
 			bis <a href="/s/<%= $journey->{arr_eva} %>?hafas=<%= $journey->{train_id} =~ m{[|]} ? 1 : 0 %>"><%= $journey->{arr_name} %></a></p>
 		% if (@{stash('connections_iris') // [] } or @{stash('connections_hafas') // []}) {
 			<span class="card-title" style="margin-top: 2ex;">Verbindungen</span>

--- a/templates/_format_train.html.ep
+++ b/templates/_format_train.html.ep
@@ -1,9 +1,10 @@
 % if ($journey->{extra_data}{wagonorder_pride}) {
 	🏳️‍🌈
 % }
+<span class="dep-line <%= $journey->{train_type} // q{} %>">
+	<%= $journey->{train_type} %>
+	<%= $journey->{train_line}  // $journey->{train_no}%>
+</span>
 % if ($journey->{train_line}) {
-	<b><%= $journey->{train_type} %> <%= $journey->{train_line} %></b> <%= $journey->{train_no} %>
-% }
-% else {
-	<%= $journey->{train_type} %> <%= $journey->{train_no} %>
+	<%= $journey->{train_no} %>
 % }

--- a/templates/_history_trains.html.ep
+++ b/templates/_history_trains.html.ep
@@ -17,7 +17,11 @@
 					% }
 					<tr>
 						<td><%= $travel->{sched_departure}->strftime($date_format) %></td>
-						<td><a href="<%= $detail_link %>"><%= $travel->{type} %> <%= $travel->{line} // $travel->{no} %></a></td>
+						<td><a href="<%= $detail_link %>">
+						<span class="dep-line <%= $travel->{type} // q{} %>">
+							<%= $travel->{type} %> <%= $travel->{line}  // $travel->{no}%>
+						</span>
+						</a></td>
 						<td>
 						<a href="<%= $detail_link %>" class="unmarked">
 						% if (param('cancelled')) {

--- a/templates/_history_trains.html.ep
+++ b/templates/_history_trains.html.ep
@@ -1,63 +1,59 @@
 <div class="row">
 	<div class="col s12">
-		<table class="striped">
-			<thead>
-				<tr>
-					<th>Datum</th>
-					<th>Fahrt</th>
-					<th>Von</th>
-					<th>Nach</th>
-				</tr>
-			</thead>
-			<tbody>
-				% for my $travel (@{$journeys}) {
-					% my $detail_link = '/journey/' . $travel->{id};
-					% if (my $prefix = stash('link_prefix')) {
-						% $detail_link = $prefix . $travel->{id};
-					% }
-					<tr>
-						<td><%= $travel->{sched_departure}->strftime($date_format) %></td>
-						<td><a href="<%= $detail_link %>">
-						<span class="dep-line <%= $travel->{type} // q{} %>">
-							<%= $travel->{type} %> <%= $travel->{line}  // $travel->{no}%>
-						</span>
-						</a></td>
-						<td>
-						<a href="<%= $detail_link %>" class="unmarked">
-						% if (param('cancelled')) {
-							%= $travel->{sched_departure}->strftime('%H:%M')
-						% }
-						% else {
-							<%= $travel->{rt_departure}->strftime('%H:%M') %>
-							% if ($travel->{sched_departure} != $travel->{rt_departure}) {
-								(<%= sprintf('%+d', ($travel->{rt_departure}->epoch - $travel->{sched_departure}->epoch) / 60) %>)
-							% }
-						% }
-						<br/>
-						<%= $travel->{from_name} %>
-						</a>
-						</td>
-						<td>
-						<a href="<%= $detail_link %>" class="unmarked">
-						% if (param('cancelled') and $travel->{sched_arrival}->epoch != 0) {
-							%= $travel->{sched_arrival}->strftime('%H:%M')
-						% }
-						% else {
-							% if ($travel->{rt_arrival}->epoch == 0 and $travel->{sched_arrival}->epoch == 0) {
-								<i class="material-icons">timer_off</i>
-							% } else {
-								%= $travel->{rt_arrival}->strftime('%H:%M');
-								% if ($travel->{sched_arrival} != $travel->{rt_arrival}) {
-									(<%= sprintf('%+d', ($travel->{rt_arrival}->epoch - $travel->{sched_arrival}->epoch) / 60) %>)
-								% }
-							% }
-						% }
-						<br/>
-						<%= $travel->{to_name} %>
-						</a></td>
-					</tr>
+		<ul class="collection history">
+		% my $olddate = '';
+		% for my $travel (@{$journeys}) {
+			% my $detail_link = '/journey/' . $travel->{id};
+			% if (my $prefix = stash('link_prefix')) {
+				% $detail_link = $prefix . $travel->{id};
+			% }
+			% my $date = $travel->{sched_departure}->strftime($date_format);
+			% if ($olddate ne $date) {
+				<li class="collection-item history-date-change">
+					<b><%= $date %></b>
+				</li>
+				% $olddate = $date
+			% }
+			<li class="collection-item">
+				<a href="<%= $detail_link %>">
+					<span class="dep-line <%= $travel->{type} // q{} %>">
+						<%= $travel->{type} %> <%= $travel->{line}  // $travel->{no}%>
+					</span>
+				</a>
+
+				<a href="<%= $detail_link %>" class="unmarked origin">
+				<i class="material-icons tiny" aria-label="von">radio_button_unchecked</i>
+				% if (param('cancelled')) {
+					%= $travel->{sched_departure}->strftime('%H:%M')
 				% }
-			</tbody>
-		</table>
+				% else {
+					<%= $travel->{rt_departure}->strftime('%H:%M') %>
+					% if ($travel->{sched_departure} != $travel->{rt_departure}) {
+						(<%= sprintf('%+d', ($travel->{rt_departure}->epoch - $travel->{sched_departure}->epoch) / 60) %>)
+					% }
+				% }
+				<strong><%= $travel->{from_name} %></strong>
+				</a>
+
+				<a href="<%= $detail_link %>" class="unmarked destination">
+				<i class="material-icons tiny" aria-label="nach">place</i>
+				% if (param('cancelled') and $travel->{sched_arrival}->epoch != 0) {
+					%= $travel->{sched_arrival}->strftime('%H:%M')
+				% }
+				% else {
+					% if ($travel->{rt_arrival}->epoch == 0 and $travel->{sched_arrival}->epoch == 0) {
+						<i class="material-icons">timer_off</i>
+					% } else {
+						%= $travel->{rt_arrival}->strftime('%H:%M');
+						% if ($travel->{sched_arrival} != $travel->{rt_arrival}) {
+							(<%= sprintf('%+d', ($travel->{rt_arrival}->epoch - $travel->{sched_arrival}->epoch) / 60) %>)
+						% }
+					% }
+				% }
+				<strong><%= $travel->{to_name} %></strong>
+			</a>
+			</li>
+		% }
+		</ul>
 	</div>
 </div>

--- a/templates/landingpage.html.ep
+++ b/templates/landingpage.html.ep
@@ -76,7 +76,7 @@
 		</div>
 	</div>
 	<h2 style="margin-left: 0.75rem;">Letzte Fahrten</h2>
-	%= include '_history_trains', date_format => '%d.%m', journeys => [journeys->get(uid => current_user->{id}, limit => 5, with_datetime => 1)];
+	%= include '_history_trains', date_format => '%d.%m.%Y', journeys => [journeys->get(uid => current_user->{id}, limit => 5, with_datetime => 1)];
 % }
 % else {
 	<div class="row">

--- a/templates/landingpage.html.ep
+++ b/templates/landingpage.html.ep
@@ -25,9 +25,9 @@
 					<div class="card-content">
 						<span class="card-title">Ausfall dokumentieren</span>
 						<p>Prinzipiell wärest du nun eingecheckt in
-							<%= $status->{train_type} %> <%= $status->{train_no} %>
+							%= include '_format_train', journey => $status
 							ab <%= $status->{dep_name} %>, doch diese Fahrt fällt aus.
-							</p>
+						</p>
 						<p>Falls du den Ausfall z.B. für Fahrgastrechte
 							dokumentieren möchtest, wähle bitte jetzt das
 							vorgesehene Ziel aus.</p>
@@ -75,7 +75,7 @@
 			% }
 		</div>
 	</div>
-	<h1>Letzte Fahrten</h1>
+	<h2 style="margin-left: 0.75rem;">Letzte Fahrten</h2>
 	%= include '_history_trains', date_format => '%d.%m', journeys => [journeys->get(uid => current_user->{id}, limit => 5, with_datetime => 1)];
 % }
 % else {


### PR DESCRIPTION
Moin,
anbei ein Konvolut aus Bugfixes und Vorschlägen, der Reihe nach:
1. 5d8f6467dc00f03957784230983ed730ec421291 fügt Titelelemente zu den meisten Seiten hinzu, damit nicht immer nur "travelynx" da steht wenn eins mehrere Tabs auf hat,
2. 6d2b5b4db3e7c4147eefe0bc401c4fe8d29382f9 hat einen sehr lapidaren Fix für #89,
3. 20e8fd39851146eb4fb3cc8cb1f7ba7fc4086d8d verteilt ein bisschen mehr Farbe. Die `_format_train` Vorlage bekommt die Farbkodierung aus der Abfahrtstafel (#93) und wird jetzt an den meisten Stellen wie auch in der Statuscard und der History-Liste verwendet,

| ![Screen Shot 2024-01-22 at 19 59 07](https://github.com/derf/travelynx/assets/46252311/c3cb2ce9-43eb-44b1-b0ef-ff407352caa1) | ![Screen Shot 2024-01-22 at 20 04 30](https://github.com/derf/travelynx/assets/46252311/8c9ca76b-2eaf-45b4-be5f-f1887b4dbc08) | ![Screen Shot 2024-01-22 at 20 06 03](https://github.com/derf/travelynx/assets/46252311/b6766ce1-b551-4eec-bc26-dea4e063e822) |
| ---- | ----- | ----- |

4. 5fe0b4ac921c338ae642f88f2f44804d285f4691 fixt (hoffentlich) #106 und #56, die bahn.expert-Link-Konstruktion ist aus meinem eigenen Projekt übernommen und hat sich dort bisher als recht zuverlässig erwiesen, und zu guter Letzt
5. mit 8b3ff460b5845c4ec86466715fc054705b635c20 ein an #93 inspiriertes neues Layout für die History, das Informationen weniger horizontal auseinanderzerrt und den Platz auf schmalen Bildschirmen besser nutzt:

| ![Screenshot 2024-01-21 at 19-39-43 travelynx](https://github.com/derf/travelynx/assets/46252311/794c4c30-ba50-4a3d-929a-b34b149eebba) | ![Screenshot from 2024-01-21 23-28-37](https://github.com/derf/travelynx/assets/46252311/14355946-c40f-4511-be16-5453d9656db3) |
| --- | --- |


Gerade was den letzten Commit angeht hoffe ich, es ist in Ordnung, so mit der Tür ins Haus zu fallen. Es hat sich so im Flow ergeben. Wenn das allgemein ein Problem ist, lass ich's in Zukunft und mach grundsätzlich erstmal ein Issue auf. Ich hätte da noch ein paar weitere Ideen für die UI, wollte aber auch keinen zu großen PR aus dem Nichts senden.
Wenn diese Änderung spezifisch nicht passt, sollte sie relativ sauber trennbar von den Fixes sein. Änderungswünsche nehme ich natürlich auch gerne an :sweat_smile: 