### PR TITLE
FGR: account for cumulative delays ≥20 minutes

### DIFF
--- a/lib/Travelynx.pm
+++ b/lib/Travelynx.pm
@@ -2459,6 +2459,7 @@ sub startup {
 	$authed_r->get('/ajax/status_card.html')->to('traveling#status_card');
 	$authed_r->get('/cancelled')->to('traveling#cancelled');
 	$authed_r->get('/fgr')->to('passengerrights#list_candidates');
+	$authed_r->get('/fgr_zeitkarten')->to('passengerrights#list_cumulative_delays');
 	$authed_r->get('/account/password')->to('account#password_form');
 	$authed_r->get('/account/mail')->to('account#change_mail');
 	$authed_r->get('/account/name')->to('account#change_name');

--- a/public/static/js/travelynx-actions.js
+++ b/public/static/js/travelynx-actions.js
@@ -317,4 +317,5 @@ $(document).ready(function() {
 		fullWidth: true,
 		indicators: true}
 	);
+	$('select').formSelect();
 });

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -144,6 +144,10 @@ ul.suggestions {
 	}
 }
 
+.collection.history.fgr > li {
+	grid-template-columns: 10ch 1fr min-content;
+}
+
 ul.route-history > li {
 	list-style: none;
 

--- a/templates/_history_trains.html.ep
+++ b/templates/_history_trains.html.ep
@@ -1,6 +1,10 @@
 <div class="row">
 	<div class="col s12">
-		<ul class="collection history">
+		% my $fgr_class = '';
+		% if (@{$journeys} && @{$journeys}[0]->{generate_fgr_target}) {
+			% $fgr_class = 'fgr';
+		%}
+		<ul class="collection history <%= $fgr_class %>">
 		% my $olddate = '';
 		% for my $travel (@{$journeys}) {
 			% my $detail_link = '/journey/' . $travel->{id};
@@ -60,6 +64,15 @@
 						</a>
 					</li>
 				</ul>
+				% if ($travel->{generate_fgr_target}) {
+					%= form_for $travel->{generate_fgr_target} => (method => 'POST') => begin
+						%= csrf_field
+						%= hidden_field id => $travel->{id}
+						<button class="btn waves-effect waves-light grey darken-3" type="submit" name="action" value="generate">
+							<i class="material-icons" aria-label="Formular herunterladen">file_download</i>
+						</button>
+					%= end
+				% }
 			</li>
 		% }
 		</ul>

--- a/templates/passengerrights.html.ep
+++ b/templates/passengerrights.html.ep
@@ -11,6 +11,18 @@
 			Die folgenden Zugfahrten sind wahrscheinliche Kandidaten dafür.
 			Details zur jeweiligen Zugfahrt sind bereits im Formular eingetragen.
 		</p>
+
+		<p>Bei <b>Zeitkarten</b> können seit dem 7. Juni 2023 Verspätungen ab 20
+			Minuten während der Gültigkeitsdauer zusammengerechnet werden. Für jede 60
+			Minuten so kumulierte Verspätung gibt es im Nahverkehr 1,50 € in der zweiten
+			und 2,25 € in der ersten Klasse, im Fernverkehr 5,00 € bzw. 7,50 €.
+			Die Anträge einer Zeitperiode müssen gemeinsam eingereicht werden.
+			Erstattungen unter 4,00 € werden nicht ausgezahlt, maximal können 25% des
+			Fahrkartenpreises erstattet werden.
+		</p>
+		<p>Diese Kriterien erfüllende Fahrten findest du hier:
+			<a href="/fgr_zeitkarten">Fahrgastrechte Zeitkarten</a>.
+		</p>
 	</div>
 </div>
 

--- a/templates/passengerrights_cumulative.html.ep
+++ b/templates/passengerrights_cumulative.html.ep
@@ -1,0 +1,100 @@
+<h1>Fahrgastrechte Zeitkarten</h1>
+<div class="row">
+	<div class="col s12">
+		<p>Bei <b>Zeitkarten</b> können seit dem 7. Juni 2023 Verspätungen ab 20
+			Minuten während der Gültigkeitsdauer zusammengerechnet werden. Für jede 60
+			Minuten so kumulierte Verspätung gibt es im Nahverkehr 1,50 € in der zweiten
+			und 2,25 € in der ersten Klasse, beim Fernverkehr 5,00 € bzw. 7,50 €.
+			Die Anträge einer Zeitperiode müssen gemeinsam eingereicht werden.
+			Erstattungen unter 4,00 € werden nicht ausgezahlt, maximal können 25% des
+			Fahrkartenpreises erstattet werden.
+		</p>
+	</div>
+</div>
+
+<form class="row">
+	<div class="col s12 m12 xl3">
+		<label for="ticket">Ich habe eine Zeitkarte für</label>
+		<select id="ticket" name="ticket_value">
+			<option value="150"
+				<%= $ticket_value == 150 ? 'selected' : '' %>
+			>Nahverkehr, 2. Kl. (1,50 €)</option>
+			<option value="225"
+				<%= $ticket_value == 225 ? 'selected' : '' %>
+			>Nahverkehr, 1. Kl. (2,25 €)</option>
+			<option value="500"
+				<%= $ticket_value == 500 ? 'selected' : '' %>
+			>Fernverkehr, 2. Kl. (5,00 €)</option>
+			<option value="750"
+				<%= $ticket_value == 750 ? 'selected' : '' %>
+			>Fernverkehr, 1. Kl. (7,50 €)</option>
+			<option value="1000"
+				<%= $ticket_value == 1000 ? 'selected' : '' %>
+			>BC100, 2. Kl. (10,00 €)</option>
+			<option value="1500"
+				<%= $ticket_value == 1500 ? 'selected' : '' %>
+			>BC100, 1. Kl. (15,00 €)</option>
+		</select>
+	</div>
+	<div class="col s12 m4 xl3">
+		<label for="start">Sie ist gültig vom</label>
+		<input id="start" name="start" type="date" value="<%= $start->ymd('-') %>" min="2023-06-07">
+	</div>
+	<div class="col s12 m4 xl3">
+		<label for="end">Bis zum</label>
+		<input id="end" name="end" type="date" value="<%= $end->ymd('-') %>">
+	</div>
+	<div class="col s12 m4 xl3">
+		<button class="btn waves-effect waves-light" type="submit">
+			Anzeigen
+			<i class="material-icons right" aria-hidden="true">send</i>
+		</button>
+	</div>
+</form>
+
+<div class="row">
+	<div class="col s12 m3 xl2">
+		Erstattungsbetrag:<br>
+		<span style="font-size:2rem">
+			% if ($compensation_amount < 400 and $compensation_amount > 0) {
+				%=  sprintf('(%.2f €) ', $compensation_amount/100)
+			% } else {
+					%= sprintf('%.2f €', $compensation_amount/100)
+			% }
+		</span>
+	</div>
+	<div class="col s12 m9 xl10" style="padding-top: 2rem">
+		<div class="progress">
+			<div class="determinate" style="width: <%= $bar_fill %>%"></div>
+		</div>
+	</div>
+</div>
+
+<div class="row">
+	<div class="col s12">
+	% if ($compensation_amount < 400) {
+		<p>
+			Wegen der Bagatellgrenze von 4,00 € müssen bei einer Entschädigung von
+			<%= sprintf('%.2f €', $ticket_value/100) %> pro Stunde
+			<b>mindestens <%= $min_delay_for_compensation %> Minuten</b> an
+			Verspätung während der Gültigkeitsdauer anfallen, damit eine Entschädigung
+			ausgezahlt wird.
+		</p>
+		% }
+		<p>
+			Im Zeitraum vom <b><%= $start->dmy('.') %></b> bis zum
+			<b><%= $end->dmy('.') %></b> sind auf <%= $num_journeys %> Fahrten insgesamt
+			<b><%= $cumulative_delay %> Minuten</b> an Verspätung angefallen.
+			% if ($ticket_value < 500) {
+				Weil du eine Zeitkarte des Nahverkehrs ausgewählt hast, werden verspätete
+				Fernzüge nicht berücksichtigt.
+			% } elsif ($ticket_value < 1000) {
+				Du hast eine Zeitkarte des Fernverkehrs ausgewählt. Sie ist vermutlich
+				nicht für alle diese Fahrten gültig, kommt aber auch mit nur einer
+				Verspätung über die Bagatellgrenze.
+			% }
+		</p>
+	</div>
+
+	%= include '_history_trains', date_format => '%d.%m.%Y', journeys => stash('journeys');
+</div>


### PR DESCRIPTION
Because metronom's reliability is approaching an area where actually getting compensation for a 49 euro ticket starts becoming feasible month-for-month by me, i've decided to implement #73:

in the FGR page there's now an explanation and link to the new cumulative delays subpage:
![Screenshot 2024-02-09 at 19-56-47 travelynx](https://github.com/derf/travelynx/assets/46252311/7d730353-38cd-4830-949a-20873c0de084)

---

there's a progress bar on how much delays you have to "earn" to get at least some of your money back, and a list of offending trains with FGR form download links:
![Screenshot 2024-02-09 at 20-02-53 travelynx Zeitkarten-Fahrgastrechte](https://github.com/derf/travelynx/assets/46252311/9cb44f55-91f1-49eb-b311-3d8a9e7f5221)
![Screenshot 2024-02-09 at 20-03-32 travelynx Zeitkarten-Fahrgastrechte](https://github.com/derf/travelynx/assets/46252311/5553cd0a-0822-4d83-bd76-595b94d2ba59)

---

you can select which ticket (for which timeframe) you're using, which will change the projected reimbursement. selecting a regional ticket excludes long-distance trains.
![Screenshot from 2024-02-09 20-03-49](https://github.com/derf/travelynx/assets/46252311/0cc9d86a-0a86-43d3-97eb-efbd0398b937)

![Screenshot 2024-02-09 at 20-07-01 travelynx Zeitkarten-Fahrgastrechte](https://github.com/derf/travelynx/assets/46252311/cd158a59-29b9-4866-9f8a-67e28d374d89)

---

this is my first contribution where i actually touched the perl code a bit. i do not know perl! the code might be awful and not idiomatic. i apologize in advance for that specifically.

have a nice weekend! :orange_heart: 