### PR TITLE
further unify train line chips

### DIFF
--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -204,6 +204,10 @@ ul.route-history > li {
 	width: fit-content;
 	min-width: 6ch;
 	margin: 0 auto;
+	.dep-train-number {
+		font-weight: 600;
+		font-style: normal;
+	}
 
 	&.Bus, &.RUF, &.AST {
 		background-color: #a3167e;
@@ -246,9 +250,11 @@ ul.route-history > li {
 	}
 	&.RJ, &.RJX {
 		background-color: #c63131;
+		font-weight: 900;
 	}
 	&.NJ, &.EN {
 		background-color: #29255b;
+		font-weight: 900;
 	}
 	&.WB {
 		background-color: #2e85ce;

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -210,7 +210,7 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.STR {
+	&.STR, &.RNV {
 		background-color: #c5161c;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
@@ -220,12 +220,12 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.U, &.STB, &.M  {
+	&.U, &.STB, &.M, &.Schw-B {
 		background-color: #014e8d;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.RE, &.IRE, &.REX {
+	&.RE, &.IRE, &.REX, &.CJX {
 		background-color: #ff4f00;
 	}
 	&.RB, &.MEX, &.TER, &.R {

--- a/templates/_cancelled_departure.html.ep
+++ b/templates/_cancelled_departure.html.ep
@@ -1,7 +1,8 @@
 <div class="card">
 	<div class="card-content">
 		<span class="card-title">Zugausfall</span>
-		<p>Die Abfahrt von <%= $journey->{train_type} %> <%= $journey->{train_no} %>
+		<p>Die Abfahrt von
+			%= include '_format_train', journey => $journey, mode => 'status'
 			in <a href="/s/<%= $journey->{dep_eva} %>"><%= $journey->{dep_name} %></a>
 			entfällt. Der Zugausfall auf der Fahrt nach <%= $journey->{arr_name} %> wurde bereits dokumentiert.
 		</p>

--- a/templates/_checked_in.html.ep
+++ b/templates/_checked_in.html.ep
@@ -7,7 +7,7 @@
 				<span class="card-title center-align">Ziel wählen</span>
 			% }
 			<span class="card-title center-align">
-				%= include '_format_train', journey => $journey
+				%= include '_format_train', journey => $journey, mode => 'status'
 			</span>
 			% if ($journey->{comment}) {
 				<p><%= $journey->{comment} %></p>

--- a/templates/_checked_out.html.ep
+++ b/templates/_checked_out.html.ep
@@ -2,7 +2,7 @@
 	<div class="card-content">
 		<span class="card-title">Ausgecheckt</span>
 		<p>Aus
-			%= include '_format_train', journey => $journey
+			%= include '_format_train', journey => $journey, mode => 'status'
 			bis <a href="/s/<%= $journey->{arr_eva} %>?hafas=<%= $journey->{train_id} =~ m{[|]} ? 1 : 0 %>"><%= $journey->{arr_name} %></a></p>
 		% if (@{stash('connections_iris') // [] } or @{stash('connections_hafas') // []}) {
 			<span class="card-title" style="margin-top: 2ex;">Verbindungen</span>

--- a/templates/_connections.html.ep
+++ b/templates/_connections.html.ep
@@ -36,9 +36,7 @@
 				% if ($train->platform) {
 					<span>Gleis <%= $train->platform %></span>
 				% }
-				<span class="dep-line <%= $train->type // q{} %>">
-					%= $train->line
-				</span>
+				%= include '_format_train', journey => $train, mode => 'iris', show_line_only => 1
 			</span>
 			<span class="dep-dest">
 				% if ($train->is_cancelled) {

--- a/templates/_connections_hafas.html.ep
+++ b/templates/_connections_hafas.html.ep
@@ -36,9 +36,7 @@
 				% if ($train->platform) {
 					<span>Gleis <%= $train->platform %></span>
 				% }
-				<span class="dep-line <%= $train->type // q{} %>">
-					%= $train->line
-				</span>
+				%= include '_format_train', journey => $train, mode => 'hafas', show_line_only => 1
 			</span>
 			<span class="dep-dest">
 				%= $via->{name}

--- a/templates/_departures_hafas.html.ep
+++ b/templates/_departures_hafas.html.ep
@@ -31,9 +31,7 @@
 				<i class="material-icons" aria-label="Keine Echtzeitdaten vorhanden" style="font-size: 16px;">gps_off</i>
 			% }
 		</a>
-		<span class="dep-line <%= $result->type // q{} %>">
-			%= $result->line
-		</span>
+		%= include '_format_train', journey => $result, mode => 'hafas', show_line_only => 1
 		<span class="dep-dest">
 			% if ($result->is_cancelled) {
 				Fahrt nach <%= $result->destination %> entfällt

--- a/templates/_departures_iris.html.ep
+++ b/templates/_departures_iris.html.ep
@@ -36,9 +36,7 @@
 				<i class="material-icons" aria-label="Keine Echtzeitdaten vorhanden" style="font-size: 16px;">gps_off</i>
 			% }
 			</a>
-			<span class="dep-line <%= $result->type // q{} %>">
-				%= $result->line
-			</span>
+			%= include '_format_train', journey => $result, mode => 'iris', show_line_only => 1
 			<span class="dep-dest">
 				% if ($result->departure_is_cancelled) {
 					Fahrt nach <%= $result->destination %> entfällt

--- a/templates/_format_train.html.ep
+++ b/templates/_format_train.html.ep
@@ -1,10 +1,53 @@
+% use List::Util;
+% my @known_train_types = qw(Bus RUF AST STR RNV S RS RER SKW U STB M Schw-B RE IRE REX CJX RB MEX TER R IC ICE EC ECE D IR TGV OGV EST TLK EIC RJ RJX NJ EN WB FLX);
+
+% # unify different train data into one set of variables we can work with
+% my ($train_no, $train_type, $train_line, $operator_code);
+% if ($mode eq 'history') {
+	% $train_type = $journey->{type};
+	% $train_line = $journey->{line};
+	% $train_no = $journey->{no};
+% } elsif ($mode eq 'status') {
+	% $train_type = $journey->{train_type};
+	% $train_line = $journey->{train_line};
+	% $train_no = $journey->{train_no};
+% } elsif ($mode eq 'hafas') {
+	% $train_type = $journey->type;
+	% $train_line = $journey->line_no;
+	% $train_no = $journey->number;
+% } elsif ($mode eq 'iris') {
+	% $train_type = $journey->type;
+	% $train_line = $journey->line_no;
+	% $train_no = $journey->train_no;
+% }
+% # account for private operator type+lines like "ME RE2" or "SBB S6", where
+% # the actual train type is hidden in the line number:
+% # check if we don't know the train type (likely a private operator prefix)
+% if ($train_type and $train_line and List::Util::none {$train_type eq $_} @known_train_types) {
+	% for my $known_train_type (@known_train_types) {
+		% # if the train line starts with a known train type, keep the operator
+		% # abbreviation, extract the actual line number and correct the train type
+		% if (index($train_line, $known_train_type) == 0) {
+			% $operator_code = $train_type;
+			% $train_type = $known_train_type;
+			% $train_line = substr $train_line, (length $known_train_type);
+		% }
+	% }
+% }
+
 % if ($journey->{extra_data}{wagonorder_pride}) {
 	🏳️‍🌈
 % }
-<span class="dep-line <%= $journey->{train_type} // q{} %>">
-	<%= $journey->{train_type} %>
-	<%= $journey->{train_line}  // $journey->{train_no}%>
+<span class="dep-line <%= $train_type %>">
+	%= $train_type
+	% # set train numbers lighter and in roman instead of italics
+	% # to avoid confusion with line numbers
+	% if ($train_line) {
+		 %= $train_line
+	% } else {
+		 <span class="dep-train-number"><%= $train_no %></span>
+	% }
 </span>
-% if ($journey->{train_line}) {
-	<%= $journey->{train_no} %>
+% if ($train_line and not stash('show_line_only')) {
+	<%= $operator_code %> <%= $train_no %>
 % }

--- a/templates/_history_trains.html.ep
+++ b/templates/_history_trains.html.ep
@@ -16,9 +16,7 @@
 			% }
 			<li class="collection-item">
 				<a href="<%= $detail_link %>">
-					<span class="dep-line <%= $travel->{type} // q{} %>">
-						<%= $travel->{type} %> <%= $travel->{line}  // $travel->{no}%>
-					</span>
+					%= include '_format_train', journey => $travel, mode => 'history', show_line_only => 1
 				</a>
 
 				<ul class="route-history">

--- a/templates/_public_status_card.html.ep
+++ b/templates/_public_status_card.html.ep
@@ -5,10 +5,10 @@
 			<i class="material-icons right sync-failed-marker grey-text" style="display: none;">sync_problem</i>
 			<span class="card-title">
 				% if (stash('from_profile')) {
-					Unterwegs mit <%= include '_format_train', journey => $journey %>
+					Unterwegs mit <%= include '_format_train', journey => $journey, mode => 'status' %>
 				% }
 				% elsif (stash('from_timeline')) {
-					<a href="/p/<%= $name %>"><%= $name %></a>: <%= include '_format_train', journey => $journey %>
+					<a href="/p/<%= $name %>"><%= $name %></a>: <%= include '_format_train', journey => $journey, mode => 'status' %>
 				% }
 				% else {
 					<a href="/p/<%= $name %>"><%= $name %></a> ist unterwegs
@@ -24,7 +24,7 @@
 			<p>
 				% if (not stash('from_profile') and not stash('from_timeline')) {
 					<div class="center-align">
-						%= include '_format_train', journey => $journey
+						%= include '_format_train', journey => $journey, mode => 'status'
 					</div>
 				% }
 				<div class="center-align countdown"

--- a/templates/landingpage.html.ep
+++ b/templates/landingpage.html.ep
@@ -25,7 +25,7 @@
 					<div class="card-content">
 						<span class="card-title">Ausfall dokumentieren</span>
 						<p>Prinzipiell wärest du nun eingecheckt in
-							%= include '_format_train', journey => $status
+							%= include '_format_train', journey => $status, mode => 'status'
 							ab <%= $status->{dep_name} %>, doch diese Fahrt fällt aus.
 						</p>
 						<p>Falls du den Ausfall z.B. für Fahrgastrechte


### PR DESCRIPTION
Currently, the departure board uses the train type as the determining factor for styling. Some private operators like Metronom, erixx, VIAS oder SBB GmbH use a three-letter abbreviation of the company name as the train type and smush the train type and line number into the line data field. This leads to RE lines being displayed in gray instead of orange, for example:
![Screenshot 2024-02-15 at 20-08-36 travelynx Unterlüß](https://github.com/derf/travelynx/assets/46252311/344f705b-35bf-454e-b0e0-e6a6805bea09)
Also in the current implementation it is not possible to tell apart two-digit train numbers with long distance trains from the line numbers the HAFAS departure board can display:
![Screenshot 2024-02-15 at 20-08-56 travelynx Hannover Hbf](https://github.com/derf/travelynx/assets/46252311/9a6e21a5-4daa-4486-9303-c62c14280449)
Is that ICE number 72 or _some train_ on ICE line 72?

This patch adds improvements for both of these visual issues.
If a train has a type we don't know about AND the line number starts with a train type we do know about, we can treat that as the actual train type to display:
![Screenshot 2024-02-15 at 19-57-57 travelynx Unterlüß](https://github.com/derf/travelynx/assets/46252311/04b7c716-3c2f-4d54-9ad0-958b1d25cdc5)
Outside of the departure board, the assumed operator prefix is not hidden and gets added in front of the train number like this:
![Screenshot 2024-02-15 at 20-18-22 travelynx](https://github.com/derf/travelynx/assets/46252311/3907856a-0ef7-46dc-8b21-b73a6e556693)

Train lines are now visually distinguished from train numbers. Train numbers are set in semi-bold and roman type. Train lines keep the formatting already applied to them, for long-distance trains that means italic and full bold.
![Screenshot 2024-02-15 at 19-57-20 travelynx Leipzig Hbf](https://github.com/derf/travelynx/assets/46252311/db2bac42-dc6b-4222-8653-f822a28a08db)
![Screenshot 2024-02-15 at 19-56-33 travelynx Hannover Hbf](https://github.com/derf/travelynx/assets/46252311/218d2be5-ff29-4915-820d-0b7c1ed122da)

The patch also allows the _format_train template to be used in all contexts and not just for checked-in statuses. It is now uniformly used in all the places that display train numbers that was able to find, including departure board and history entries. It also adds the train types RNV (displayed like STR), Schw-B (like U) and CJX (like RE) to the set of styled train types.