### PR TITLE
Allow setting backend id in import (Fixes #162)

### DIFF
--- a/lib/Travelynx/Controller/Api.pm
+++ b/lib/Travelynx/Controller/Api.pm
@@ -530,6 +530,7 @@ sub import_v1 {
 			),
 			comment => sanitize( q{}, $payload->{comment} ),
 			lax     => $payload->{lax} ? 1 : 0,
+			backend_id => sanitize( 0, $payload->{backend_id} ),
 		);
 
 		if ( $payload->{intermediateStops}

--- a/templates/api_documentation.html.ep
+++ b/templates/api_documentation.html.ep
@@ -204,6 +204,7 @@
 			"dryRun" : true/false, (optional: wenn true, wird die Eingabe validiert, aber keine Fahrt angelegt)<br/>
 			"lax" : true/false, (optional: wenn true, werden unbekannte Unterwegshalte akzeptiert)<br/>
 			"cancelled" : true/false, (Ausfall?)<br/>
+			"backend_id": 0 (optional: Backend-ID)<br/>
 			"train" : {<br/>
 			"type" : "S", (Typ, z.B. ICE, RE, S, U)<br/>
 			"line" : "6", (Linie als String, bei Zügen ohne Linie wie IC/ICE u.ä. null)<br/>


### PR DESCRIPTION
This change allows data to be imported again by including a backend_id into the journey when importing.