### PR TITLE
Update perl to v5.30 to fix OCI image manifest version

### DIFF
--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.20'
+          - '5.30'
           - 'latest'
           - 'threaded'
 


### PR DESCRIPTION
More context: https://github.com/Perl/docker-perl/issues/161
Fixes: https://github.com/derf/travelynx/actions/runs/11357386953