### PR TITLE
Account for station arrival and departure times when highlighting route in journey view

### DIFF
--- a/templates/journey.html.ep
+++ b/templates/journey.html.ep
@@ -218,10 +218,16 @@
 						% my $within = 0;
 						% my $at_startstop = 0;
 						% for my $station (@{$journey->{route}}) {
-							% if (($station->[1] and $station->[1] == $journey->{from_eva}) or $station->[0] eq $journey->{from_name}) {
+							% my $station_is_from_eva = ($station->[1] and $station->[1] == $journey->{from_eva});
+							% my $station_is_to_eva = ($station->[1] and $station->[1] == $journey->{to_eva});
+							% my $station_is_from_name = ($station->[0] eq $journey->{from_name});
+							% my $station_is_to_name = ($station->[0] eq $journey->{to_name});
+							% my $station_is_dep_time = (!$station->[2]{sched_dep} or DateTime->compare($station->[2]{sched_dep}, $journey->{sched_departure}) == 0);
+							% my $station_is_arr_time = (!$station->[2]{sched_arr} or DateTime->compare($station->[2]{sched_arr}, $journey->{sched_arrival}) == 0);
+							% if (($station_is_from_eva or $station_is_from_name) and $station_is_dep_time) {
 								% $within = 1; $at_startstop = 1;
 							% }
-							% elsif (($station->[1] and $station->[1] == $journey->{to_eva}) or $station->[0] eq $journey->{to_name}) {
+							% elsif (($station_is_to_eva or $station_is_to_name) and $station_is_arr_time and $within) {
 								% $within = 0; $at_startstop = 1;
 							% }
 							% else {
@@ -254,7 +260,7 @@
 									% }
 								</span>
 							% }
-							% if (($station->[1] and $station->[1] == $journey->{from_eva}) or $station->[0] eq $journey->{from_name}) {
+							% if (($station_is_from_eva or $station_is_from_name) and $station_is_dep_time) {
 								% $before = 0;
 							% }
 							<br/>


### PR DESCRIPTION
The page template for the journey view highlights the stations in the route which form part of the journey. However, it assumes that the route does not pass through the same station more than once.

My real-world example which violates this assumption is BVG bus line 390, which both starts and ends at S Ahrensfelde Bhf and *also* passes through some intermediate stops like Ahrensfelde Friedhof Bhf twice. Taking journey from Ahrensfelde Friedhof Bhf the *second* time the bus stops there to the terminal stop of S Ahrensfelde Bhf results in the initial departure stop at S Ahrensfelde Bhf being highlighted, as well as the rest of the route starting at the *first* stop at Friedhof Bhf.

This change extends the algorithm which applies the highlight styling to account for the arrival and departure times for each stop on the route where available, and attempts to match them to the journey arrival and departure times. (This ensures that the correct occurrence of Ahrensfelde Friedhof Bhf is selected.) Additionally, it also adjusts the condition for detecting the last station of the journey of the route so that it doesn't trigger until the first station has been found. (This ensures that the initial departure stop at S Ahrensfelde Bhf is not incorrectly highlighted.) This should also improve the journey highlighting for other ring lines like the Berliner Ringbahn as well.