### PR TITLE
Text change to reflect ÖPNV integration

### DIFF
--- a/lib/Travelynx.pm
+++ b/lib/Travelynx.pm
@@ -788,7 +788,7 @@ sub startup {
 
 			if ( not $user->{checked_in} and not $user->{cancelled} ) {
 				return $promise->resolve( 0,
-					'You are not checked into any train' );
+					'You are not checked in' );
 			}
 
 			if ( $dep_eva and $dep_eva != $user->{dep_eva} ) {


### PR DESCRIPTION
This PR removes a reference to "train" in a message that is shown when the user is not checked in at the moment.