### PR TITLE
Persist train_color and train_text_color in json

### DIFF
--- a/lib/Travelynx.pm
+++ b/lib/Travelynx.pm
@@ -2146,6 +2146,13 @@ sub startup {
 					}
 				}
 
+				if ( $in_transit->{data}{train_color} ) {
+					$ret->{train_color} = $in_transit->{data}{train_color};
+				}
+				if ( $in_transit->{data}{train_text_color} ) {
+					$ret->{train_text_color} = $in_transit->{data}{train_text_color};
+				}
+
 				return $ret;
 			}
 
@@ -2202,43 +2209,45 @@ sub startup {
 					$latest->{arr_name}  = $station->{name};
 				}
 				return {
-					checked_in      => 0,
-					cancelled       => 0,
-					cancellation    => $latest_cancellation,
-					backend_id      => $latest->{backend_id},
-					backend_name    => $latest->{backend_name},
-					is_dbris        => $latest->{is_dbris},
-					is_iris         => $latest->{is_iris},
-					is_hafas        => $latest->{is_hafas},
-					is_motis        => $latest->{is_motis},
-					journey_id      => $latest->{journey_id},
-					timestamp       => $action_time,
-					timestamp_delta => $now->epoch - $action_time->epoch,
-					train_type      => $latest->{train_type},
-					train_line      => $latest->{train_line},
-					train_no        => $latest->{train_no},
-					train_id        => $latest->{train_id},
-					sched_departure => epoch_to_dt( $latest->{sched_dep_ts} ),
-					real_departure  => epoch_to_dt( $latest->{real_dep_ts} ),
-					dep_ds100       => $latest->{dep_ds100},
-					dep_eva         => $latest->{dep_eva},
-					dep_external_id => $latest->{dep_external_id},
-					dep_name        => $latest->{dep_name},
-					dep_lat         => $latest->{dep_lat},
-					dep_lon         => $latest->{dep_lon},
-					dep_platform    => $latest->{dep_platform},
-					sched_arrival   => epoch_to_dt( $latest->{sched_arr_ts} ),
-					real_arrival    => epoch_to_dt( $latest->{real_arr_ts} ),
-					arr_ds100       => $latest->{arr_ds100},
-					arr_eva         => $latest->{arr_eva},
-					arr_external_id => $latest->{arr_external_id},
-					arr_name        => $latest->{arr_name},
-					arr_lat         => $latest->{arr_lat},
-					arr_lon         => $latest->{arr_lon},
-					arr_platform    => $latest->{arr_platform},
-					comment         => $latest->{user_data}{comment},
-					visibility      => $latest->{visibility},
-					visibility_str  => $latest->{visibility_str},
+					checked_in       => 0,
+					cancelled        => 0,
+					cancellation     => $latest_cancellation,
+					backend_id       => $latest->{backend_id},
+					backend_name     => $latest->{backend_name},
+					is_dbris         => $latest->{is_dbris},
+					is_iris          => $latest->{is_iris},
+					is_hafas         => $latest->{is_hafas},
+					is_motis         => $latest->{is_motis},
+					journey_id       => $latest->{journey_id},
+					timestamp        => $action_time,
+					timestamp_delta  => $now->epoch - $action_time->epoch,
+					train_type       => $latest->{train_type},
+					train_line       => $latest->{train_line},
+					train_no         => $latest->{train_no},
+					train_id         => $latest->{train_id},
+					train_color		 => $latest->{user_data}{train_color},
+					train_text_color => $latest->{user_data}{train_text_color},
+					sched_departure  => epoch_to_dt( $latest->{sched_dep_ts} ),
+					real_departure   => epoch_to_dt( $latest->{real_dep_ts} ),
+					dep_ds100        => $latest->{dep_ds100},
+					dep_eva          => $latest->{dep_eva},
+					dep_external_id  => $latest->{dep_external_id},
+					dep_name         => $latest->{dep_name},
+					dep_lat          => $latest->{dep_lat},
+					dep_lon          => $latest->{dep_lon},
+					dep_platform     => $latest->{dep_platform},
+					sched_arrival    => epoch_to_dt( $latest->{sched_arr_ts} ),
+					real_arrival     => epoch_to_dt( $latest->{real_arr_ts} ),
+					arr_ds100        => $latest->{arr_ds100},
+					arr_eva          => $latest->{arr_eva},
+					arr_external_id  => $latest->{arr_external_id},
+					arr_name         => $latest->{arr_name},
+					arr_lat          => $latest->{arr_lat},
+					arr_lon          => $latest->{arr_lon},
+					arr_platform     => $latest->{arr_platform},
+					comment          => $latest->{user_data}{comment},
+					visibility       => $latest->{visibility},
+					visibility_str   => $latest->{visibility_str},
 					effective_visibility     => $latest->{effective_visibility},
 					effective_visibility_str =>
 					  $latest->{effective_visibility_str},

--- a/lib/Travelynx/Model/InTransit.pm
+++ b/lib/Travelynx/Model/InTransit.pm
@@ -328,6 +328,8 @@ sub add {
 				data            => JSON->new->encode(
 					{
 						rt => $stopover->{is_realtime} ? 1 : 0,
+						train_color => $journey->route_color,
+						train_text_color => $journey->route_text_color,
 						%{ $data // {} }
 					}
 				),

--- a/lib/Travelynx/Model/Journeys.pm
+++ b/lib/Travelynx/Model/Journeys.pm
@@ -282,10 +282,17 @@ sub add_from_in_transit {
 	my ( $self, %opt ) = @_;
 	my $db      = $opt{db};
 	my $journey = $opt{journey};
+	my $data   = JSON->new->decode( $journey->{data} );
 
 	delete $journey->{data};
 	$journey->{edited}        = 0;
 	$journey->{checkout_time} = DateTime->now( time_zone => 'Europe/Berlin' );
+	$journey->{user_data} = JSON->new->encode(
+		{
+			train_color => $data->{train_color},
+			train_text_color => $data->{train_text_color},
+		}
+	);
 
 	return $db->insert( 'journeys', $journey, { returning => 'id' } )
 	  ->hash->{id};

--- a/templates/_departures_motis.html.ep
+++ b/templates/_departures_motis.html.ep
@@ -32,7 +32,7 @@
 				<i class="material-icons" aria-label="Keine Echtzeitdaten vorhanden" style="font-size: 16px;">gps_off</i>
 			% }
 		</a>
-		<span class="dep-line <%= $result->mode %>" style="background-color: #<%= $result->route_color // q{} %>;">
+		<span class="dep-line <%= $result->mode %>" style="color: #<%= $result->route_text_color // q{} %>; background-color: #<%= $result->route_color // q{} %>;">
 			%= $result->route_name
 		</span>
 		<span class="dep-dest">

--- a/templates/_format_train.html.ep
+++ b/templates/_format_train.html.ep
@@ -1,7 +1,7 @@
 % if ($journey->{extra_data}{wagonorder_pride}) {
 	🏳️‍🌈
 % }
-<span class="dep-line <%= $journey->{train_type} // q{} %>">
+<span class="dep-line <%= $journey->{train_type} // q{} %>" style="color: #<%= $journey->{train_text_color} // q{} %>; background-color: #<%= $journey->{train_color} // q{} %>;">
 	% if (not $journey->{is_motis}) {
 		<%= $journey->{train_type} %>
 	% }

--- a/templates/_history_trains.html.ep
+++ b/templates/_history_trains.html.ep
@@ -16,7 +16,7 @@
 			% }
 			<li class="collection-item">
 				<a href="<%= $detail_link %>">
-					<span class="dep-line <%= $travel->{type} // q{} %>">
+					<span class="dep-line <%= $travel->{type} // q{} %>" style="color: #<%= $travel->{user_data}{train_text_color} %>; background-color: #<%= $travel->{user_data}{train_color} %>;">
 						% if (not $travel->{is_motis}) {
 							<%= $travel->{type} %>
 						% }


### PR DESCRIPTION
This patch adds back the custom colors introduced with MOTIS support and subsequently removed in 94c8b5a7d1e2cb7f73b0eca7e33d916775504cd4, by persisting them in the data and user_data json for in_transit and journeys respectively.

Depends on https://github.com/derf/Travel-Status-MOTIS/pull/2 for text colors.

![image](https://github.com/user-attachments/assets/c299a189-6d9d-4565-9a11-c1937dcca1fc)
![image](https://github.com/user-attachments/assets/b0264d14-2619-4fca-bbd0-713a10143ea3)
