### PR TITLE
local.scss: Add some EFA trip types

### DIFF
--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -209,12 +209,12 @@ ul.route-history > li {
 	min-width: 6ch;
 	margin: 0 auto;
 
-	&.Bus, &.BUS, &.RUF, &.AST, &.NachtBus, &.Niederflurbus, &.Stadtbus, &.MetroBus, &.PlusBus, &.RegionalBus, &.ExpressBus, &.RufTaxi {
+	&.Bus, &.BUS, &.RUF, &.AST, &.NachtBus, &.Niederflurbus, &.Stadtbus, &.MetroBus, &.PlusBus, &.Landbus, &.Regionalbus, &.RegionalBus, &.SB, &.ExpressBus, &.RufTaxi, &.Rufbus, &.Linientaxi, &.BSV, &.RVV-Bus-Linie {
 		background-color: #a3167e;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.STR, &.Tram, &.TRAM, &.Str, &.Strb, &.STB, &.Straenbahn, &.NachtTram {
+	&.STR, &.Tram, &.TRAM, &.Str, &.Strb, &.STB, &.Straenbahn, &.NachtTram, &.Stadtbahn, &.Niederflurstrab {
 		background-color: #c5161c;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
@@ -224,7 +224,7 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.U, &.M, &.SUBWAY, &.U-Bahn {
+	&.U, &.M, &.SUBWAY, &.U-Bahn, &.UBAHN {
 		background-color: #014e8d;
 		border-radius: 5rem;
 		padding: .2rem .5rem;

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -209,7 +209,7 @@ ul.route-history > li {
 	min-width: 6ch;
 	margin: 0 auto;
 
-	&.Bus, &.BUS, &.RUF, &.AST, &.NachtBus, &.Niederflurbus, &.Stadtbus, &.MetroBus, &.PlusBus, &.Landbus, &.Regionalbus, &.RegionalBus, &.SB, &.ExpressBus, &.RufTaxi, &.Rufbus, &.Linientaxi, &.BSV, &.RVV-Bus-Linie {
+	&.Bus, &.BUS, &.RUF, &.AST, &.NachtBus, &.Niederflurbus, &.Stadtbus, &.MetroBus, &.PlusBus, &.Landbus, &.Regionalbus, &.RegionalBus, &.SB, &.ExpressBus, &.RufTaxi, &.Rufbus, &.Linientaxi, &.BSV, &.RVV-Bus-Linie, &.Buslinie, &.Omnibus, &.RegioBus {
 		background-color: #a3167e;
 		border-radius: 5rem;
 		padding: .2rem .5rem;


### PR DESCRIPTION
Hi, I'll have a go at my first PR. I was trying to do it the way it was done in #247. I hope I haven't made too many mistakes ^^.
The newly supported EFA backends come with some (sometimes oddly specific) trip types. I tried to find as many as possible and add them to the local.scss file.

This commit adds the trip types "SB", "Rufbus", "Regionalbus", "Landbus", "BSV", "RVV-Bus-Linie", "Omnibus", "Buslinie" and "RegioBus" to the "Bus" category. 
- SB: Used for CE-busses in Wuppertal
- Rufbus: Used for several AST services
- Regionalbus: Used for several bus services, especially in Bavaria
- Landbus: Used e.g. for the bus service 890 Oberstaufen - Krumbach (AT)
- BSV: Used for SEV bus services
- RVV-Bus-Linie: Used for several bus services in the Regensburger Verkehrsverbund
- Omnibus: Used for bus services around Hameln
- Buslinie: Used e.g. for bus service Sigmaringen - Meßkirch
- RegioBus: Used e.g. for bus service Friedrichshafen - Ravensburg

It adds the trip types "Stadtbahn" and "Niederflurstrab" to the "Tram" category. 
- Stadtbahn: Used for tram services around Cologne
- Niederflurstrab: Used for tram services in the Rhine-Ruhr area

It adds the trip type "UBAHN" to the "U-Bahn" category.
- UBAHN: Used for the subway services in Nuremberg

I would have liked to add the trip type "Straßenbahn" to the "Tram" category, but the ß seemed to cause an error, so I left it out for now.