### PR TITLE
local.scss: Add AST and ship category. Add Schwebebahn services to U-Bahn category

### DIFF
--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -208,9 +208,20 @@ ul.route-history > li {
 	width: fit-content;
 	min-width: 6ch;
 	margin: 0 auto;
-
-	&.Bus, &.BUS, &.RUF, &.AST, &.NachtBus, &.Niederflurbus, &.Stadtbus, &.MetroBus, &.PlusBus, &.Landbus, &.Regionalbus, &.RegionalBus, &.SB, &.ExpressBus, &.RufTaxi, &.Rufbus, &.Linientaxi, &.BSV, &.RVV-Bus-Linie, &.Buslinie, &.Omnibus, &.RegioBus {
+	
+	&.Bus, &.BUS, &.NachtBus, &.Niederflurbus, &.Stadtbus, &.MetroBus, &.PlusBus, &.Landbus, &.Regionalbus, &.RegionalBus, &.SB, &.ExpressBus, &.BSV, &.RVV-Bus-Linie, &.Buslinie, &.Omnibus, &.RegioBus {
 		background-color: #a3167e;
+		border-radius: 5rem;
+		padding: .2rem .5rem;
+	}
+	&.RUF, &.AST, &.RufTaxi, &.Rufbus, &.Linientaxi {
+		background-color: #ffd800;
+		color: black;
+		border-radius: 5rem;
+		padding: .2rem .5rem;
+	}
+	&.Fhre, &.Fh, &.Schiff, &.SCH, &.KAT {
+		background-color: #309fd1;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
@@ -224,7 +235,7 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.U, &.M, &.SUBWAY, &.U-Bahn, &.UBAHN {
+	&.U, &.M, &.SUBWAY, &.U-Bahn, &.UBAHN, &.Schw-B, &.Schwebebahn, &.H-Bahn {
 		background-color: #014e8d;
 		border-radius: 5rem;
 		padding: .2rem .5rem;


### PR DESCRIPTION
If I have correctly understood how the file works, then this PR should add distinct colors for AST and ship services.
I've used the colors used in the respective bahn.de/Navigator category icons. These are #ffd800 for AST services and #309fd1 for ship services. The yellow might be a bit too bright, so feel free to adjust it if you like.

Here are some examples:
![Fähren](https://github.com/user-attachments/assets/4c12af26-9a4e-444c-a2d7-7f003f3df2a2)
![Fähren_light](https://github.com/user-attachments/assets/5888e7e0-2456-4d54-a9e5-aa10fe0bda0a)
Ship services in dark and light mode.

![AST](https://github.com/user-attachments/assets/756d29ac-6057-49b1-bd7c-41505b1b8b61)
![AST_light](https://github.com/user-attachments/assets/b2a3e925-bfb1-403e-93a8-80089fd8d440)
AST services in dark and light mode.

Additionally, I've added the "Schwebebahn" services to the "U-Bahn" category color-wise. This is of course debatable, bahn.de uses the Tram category for these services while they are technically most likely a U-Bahn.

(I know I'm currently posting a lot of contributions, please take your time and don't feel compelled to review them right away :))