### PR TITLE
Update map data source & quality note

### DIFF
--- a/templates/history_map.html.ep
+++ b/templates/history_map.html.ep
@@ -116,8 +116,8 @@
 <div class="row">
 	<div class="col s12">
 		<p>
-			Die eingezeichneten Routen stammen aus dem HAFAS und sind im Detail
-			oft fehlerbehaftet.
+			Die eingezeichneten Routen stammen aus dem Backend, mit dem die Fahrt aufgezeichnet wurde.
+			Die Datenqualität variiert.
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
This PR revises the informational text to clarify that routes are sourced from the backend used for recording trips. 
The data quality note was updated accordingly.

If this breaks formatting or whatever, just let me know and I'll come up with a shorter suggestion. 