### PR TITLE
update_arrival_motis: store arrival platform, if available

### DIFF
--- a/lib/Travelynx/Model/InTransit.pm
+++ b/lib/Travelynx/Model/InTransit.pm
@@ -1369,7 +1369,8 @@ sub update_arrival_motis {
 	$db->update(
 		'in_transit',
 		{
-			real_arrival => $stopover->{realtime_arrival},
+			real_arrival => $stopover->realtime_arrival,
+			arr_platform => $stopover->track,
 			route        => $json->encode( [@route] ),
 		},
 		{


### PR DESCRIPTION
See b4879a8a48ccecf1071d1ed76a02fecfb4eba3b6

I noticed that all of these are gated behind realtime data being available (eg https://github.com/derf/travelynx/blob/96a074acba60738ad61ca58311164a75d578413c/lib/Travelynx/Command/work.pm#L363)
