### PR TITLE
Journeys->add: allow consecutive route stops at the same timestamp

### DIFF
--- a/lib/Travelynx/Model/Journeys.pm
+++ b/lib/Travelynx/Model/Journeys.pm
@@ -201,9 +201,9 @@ sub add {
 				$ts      = $parser->parse_datetime( $+{timestamp} );
 				if ($ts) {
 					my $epoch = $ts->epoch;
-					if ( $epoch <= $prev_epoch ) {
+					if ( $epoch < $prev_epoch ) {
 						return ( undef,
-'Zeitstempel der Unterwegshalte müssen streng monoton steigend sein (keine Zeitreisen und keine Portale)'
+'Zeitstempel der Unterwegshalte müssen monoton steigend sein (keine Zeitreisen und keine Portale)'
 						);
 					}
 					$station_data{sched_arr} = $epoch;


### PR DESCRIPTION
This pull request relaxes the route timestamp sanity checking introduced in 9e6728a3e14fbe48b7e7aa1d7c0ae2d4e79f0ece by allowing the same timestamp (usually minute accuracy) to occur multiple times for consecutive stops. This is common for trams, for example.

See https://travelynx.de/p/networkException/j/1459423?token=10543-320-1748928540.000000