### PR TITLE
Improve wording and remove train references

### DIFF
--- a/templates/_cancelled_departure.html.ep
+++ b/templates/_cancelled_departure.html.ep
@@ -1,9 +1,9 @@
 <div class="card">
 	<div class="card-content">
-		<span class="card-title">Zugausfall</span>
+		<span class="card-title">Fahrtausfall</span>
 		<p>Die Abfahrt von <%= $journey->{train_type} %> <%= $journey->{train_no} %>
 			in <a href="/s/<%= $journey->{dep_eva} %>"><%= $journey->{dep_name} %></a>
-			entfällt. Der Zugausfall auf der Fahrt nach <%= $journey->{arr_name} %> wurde bereits dokumentiert.
+			entfällt. Der Ausfall der Fahrt nach <%= $journey->{arr_name} %> wurde bereits dokumentiert.
 		</p>
 		% if (my @connections = @{stash('connections_iris') // []}) {
 			<p>Alternative Reisemöglichkeiten:</p>

--- a/templates/cancelled.html.ep
+++ b/templates/cancelled.html.ep
@@ -1,7 +1,7 @@
-<h1>Zugausfälle</h1>
+<h1>Ausfälle</h1>
 <div class="row">
 	<div class="col s12">
-		Die folgenden Zugfahrten haben nicht stattgefunden.
+		Die folgenden Fahrten haben nicht wie geplant stattgefunden.
 	</div>
 </div>
 

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -90,7 +90,7 @@
 					</div>
 				</li>
 				% if ($acc) {
-					<li class="<%= navbar_class('/history') %>"><a href='/history' title="Vergangene Zugfahrten"><i class="material-icons" aria-label="Vergangene Zugfahrten">history</i></a></li>
+					<li class="<%= navbar_class('/history') %>"><a href='/history' title="Vergangene Fahrten"><i class="material-icons" aria-label="Vergangene Fahrten">history</i></a></li>
 					<li class="<%= navbar_class('/account') %>"><a href="/account" title="Account"><i class="material-icons" aria-label="Account"><%= $acc->{notifications} ? 'notifications' : 'account_circle' %></i></a></li>
 				% }
 				% else {

--- a/templates/passengerrights.html.ep
+++ b/templates/passengerrights.html.ep
@@ -3,13 +3,13 @@
 	<div class="col s12">
 		<p>
 			Ab 60 Minuten Verspätung am Ziel besteht in einigen Fällen ein
-			Entschädigungsanspruch gegenüber dem Eisenbahnverkehrsunternehmen.
+			Entschädigungsanspruch gegenüber dem Verkehrsunternehmen.
 			Dieser kann mit dem Fahrgastrechteformular oder online geltend
 			gemacht werden.
 		</p>
 		<p>
-			Die folgenden Zugfahrten sind wahrscheinliche Kandidaten dafür.
-			Details zur jeweiligen Zugfahrt sind bereits im Formular eingetragen.
+			Die folgenden Fahrten sind wahrscheinliche Kandidaten dafür.
+			Details zur jeweiligen Fahrt sind bereits im Formular eingetragen.
 		</p>
 	</div>
 </div>
@@ -20,7 +20,7 @@
 			<thead>
 				<tr>
 					<th>Datum</th>
-					<th>Zug</th>
+					<th>Fahrt</th>
 					<th>Grund</th>
 					<th>Formular</th>
 				</tr>
@@ -79,7 +79,7 @@
 		<p>
 			Bei Abo-Tickets besteht teilweise die Möglichkeit, bereits ab 20
 			Minuten Verspätung Fahrten gesammelt zu Entschädigungszwecken
-			einzureichen. Die folgenden Zugfahrten sind Kandidaten dafür.
+			einzureichen. Die folgenden Fahrten sind Kandidaten dafür.
 			Fahrten mit einer Verspätung von 60 Minuten oder mehr werden hier
 			nicht aufgeführt.
 		</p>
@@ -92,7 +92,7 @@
 			<thead>
 				<tr>
 					<th>Datum</th>
-					<th>Zug</th>
+					<th>Fahrt</th>
 					<th>Verspätung</th>
 				</tr>
 			</thead>


### PR DESCRIPTION
This PR improves the wording on some pages and adjusts some pages to make clear that travelynx also supports non train journeys.