### PR TITLE
More train-color bubbles

### DIFF
--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -225,7 +225,7 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.STR, &.Tram, &.TRAM, &.Str, &.Strb, &.STB, &.Straenbahn, &.NachtTram, &.Stadtbahn, &.Niederflurstrab {
+	&.STR, &.Tram, &.TRAM, &.Str, &.Strb, &.STB, &.Straenbahn, &.NachtTram, &.Stadtbahn, &.Niederflurstrab, &.Trm {
 		background-color: #c5161c;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
@@ -246,6 +246,8 @@ ul.route-history > li {
 	&.RB, &.MEX, &.TER, &.R, &.REGIONAL_RAIL, &.Regionalzug, &.R-Bahn, &.BRB {
 		background-color: #1f4a87;
 	}
+	// BE
+	&.ECD,
 	// DE
 	&.IC, &.ICE, &.EC, &.ECE, &.D,
 	// CH

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -246,7 +246,7 @@ ul.route-history > li {
 	&.RB, &.MEX, &.TER, &.R, &.REGIONAL_RAIL, &.Regionalzug, &.R-Bahn, &.BRB {
 		background-color: #1f4a87;
 	}
-	// BE
+	// BE / NL
 	&.ECD,
 	// DE
 	&.IC, &.ICE, &.EC, &.ECE, &.D,
@@ -254,8 +254,10 @@ ul.route-history > li {
 	&.IR,
 	// FR
 	&.TGV, &.OGV, &.EST,
+	// IT
+	&.FR,
 	// PL
-	&.TLK, &.EIC,
+	&.TLK, &.EIC, &.EIP,
 	// MOTIS
 	&.HIGHSPEED_RAIL, &.LONG_DISTANCE {
 		background-color: #ff0404;
@@ -266,7 +268,7 @@ ul.route-history > li {
 	&.RJ, &.RJX {
 		background-color: #c63131;
 	}
-	&.NJ, &.EN, &.NIGHT_RAIL {
+	&.NJ, &.EN, &.NIGHT_RAIL, &.ICN {
 		background-color: #29255b;
 	}
 	&.WB {


### PR DESCRIPTION
Weitere paar fehlende Zuordnungen ergänzt

ICN - Intercity Notte zu Nachtzügen hinzugefügt
FR - Frecciarossa zu Highspeedzügen hinzugefügt
EIP - Express Intercity Premium zu Highspeedzügen hinzugefügt