### PR TITLE
Startseite - Doppelter String entfernt

### DIFF
--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -225,7 +225,7 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.STR, &.Tram, &.TRAM, &.Str, &.Strb, &.STB, &.Straenbahn, &.NachtTram, &.Stadtbahn, &.Niederflurstrab {
+	&.STR, &.Tram, &.TRAM, &.Str, &.Strb, &.STB, &.Straenbahn, &.NachtTram, &.Stadtbahn, &.Niederflurstrab, &.Trm {
 		background-color: #c5161c;
 		border-radius: 5rem;
 		padding: .2rem .5rem;
@@ -246,6 +246,8 @@ ul.route-history > li {
 	&.RB, &.MEX, &.TER, &.R, &.REGIONAL_RAIL, &.Regionalzug, &.R-Bahn, &.BRB {
 		background-color: #1f4a87;
 	}
+	// BE
+	&.ECD,
 	// DE
 	&.IC, &.ICE, &.EC, &.ECE, &.D,
 	// CH

--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -246,7 +246,7 @@ ul.route-history > li {
 	&.RB, &.MEX, &.TER, &.R, &.REGIONAL_RAIL, &.Regionalzug, &.R-Bahn, &.BRB {
 		background-color: #1f4a87;
 	}
-	// BE
+	// BE / NL
 	&.ECD,
 	// DE
 	&.IC, &.ICE, &.EC, &.ECE, &.D,
@@ -254,8 +254,10 @@ ul.route-history > li {
 	&.IR,
 	// FR
 	&.TGV, &.OGV, &.EST,
+	// IT
+	&.FR,
 	// PL
-	&.TLK, &.EIC,
+	&.TLK, &.EIC, &.EIP,
 	// MOTIS
 	&.HIGHSPEED_RAIL, &.LONG_DISTANCE {
 		background-color: #ff0404;
@@ -266,7 +268,7 @@ ul.route-history > li {
 	&.RJ, &.RJX {
 		background-color: #c63131;
 	}
-	&.NJ, &.EN, &.NIGHT_RAIL {
+	&.NJ, &.EN, &.NIGHT_RAIL, &.ICN {
 		background-color: #29255b;
 	}
 	&.WB {

--- a/templates/landingpage.html.ep
+++ b/templates/landingpage.html.ep
@@ -116,7 +116,6 @@
 				<ul>
 					<li><%= L('landingpage.features.log') %></li>
 					<li><%= L('landingpage.features.share') %></li>
-					<li><%= L('landingpage.features.share') %></li>
 					<li><%= L('landingpage.features.api-pre') %> <a href="/api"><%= L('landingpage.features.api-link') %></a> <%= L('landingpage.features.api-post') %></li>
 					<li><%= L('landingpage.features.stats') %></li>
 					<li><%= L('landingpage.features.passenger-rights') %></li>


### PR DESCRIPTION
Auf der Startseite (wenn der Benutzer nicht angemeldet ist) wurde das Feature "Teilen von aktuellen und vergangenen Fahrten mit anderen Personen" doppelt erwähnt. 

Ist mit dem aktuellen Commit korrigiert.