### PR TITLE
local.scss: Add FERRY chip selector

### DIFF
--- a/sass/src/common/local.scss
+++ b/sass/src/common/local.scss
@@ -220,7 +220,7 @@ ul.route-history > li {
 		border-radius: 5rem;
 		padding: .2rem .5rem;
 	}
-	&.Fhre, &.Fh, &.Schiff, &.SCH, &.KAT {
+	&.Fhre, &.Fh, &.Schiff, &.SCH, &.KAT, &.FERRY {
 		background-color: #309fd1;
 		border-radius: 5rem;
 		padding: .2rem .5rem;


### PR DESCRIPTION
This PR adds the trip type "FERRY" to the "Boat" category.

I‘m providing this PR because of this instance: https://travelynx.de/s/it-Sardegna-Ferries-Collegamenti-isole-minori_ITCLS?motis=transitous