### PR TITLE
fix dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	libssl-dev \
 	make \
 	zlib1g-dev \
+	libxml2 \
+	libxml2-dev \
 	&& cpanm -in --no-man-pages --installdeps . \
 	&& rm -rf ~/.cpanm \
 	&& apt-get purge -y \


### PR DESCRIPTION
As title.
`libxml2-dev` is needed for the container/project to build, `libxml2` is needed at runtime.
I'm also planning to contribute additionally to the documentation and generally stuff regarding docker.
