### PR TITLE
public status card: some fixes for copy checkin

### DIFF
--- a/templates/_public_status_card.html.ep
+++ b/templates/_public_status_card.html.ep
@@ -310,8 +310,14 @@
 					% elsif ( $journey->{is_motis} ) {
 						data-motis="<%= $journey->{backend_name} %>"
 					% }
-					data-station="<%= $journey->{dep_eva} %>"
-					data-dest="<%= $journey->{arr_eva} %>"
+					% if ( $journey->{is_motis} ) {
+						data-station="<%= $journey->{dep_external_id} %>"
+						data-dest="<%= $journey->{arr_external_id} %>"
+					% }
+					% else {
+						data-station="<%= $journey->{dep_eva} %>"
+						data-dest="<%= $journey->{arr_eva} %>"
+					% }
 					data-train="<%= $journey->{train_id} %>"
 					data-ts="<%= ( $journey->{sched_departure} // $journey->{real_departure} )->epoch %>"
 				>


### PR DESCRIPTION
This pull request fixes
- an issue with DBRIS where copying a checkin would result in "$train_type $train_no" and
- copying not working with MOTIS at all

Follow up to #386