### PR TITLE
Update docker image tags to newer and fully-qualified version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as files
+FROM docker.io/debian:buster-slim as files
 
 ARG travelynx_version=git
 
@@ -18,7 +18,7 @@ RUN ln -sf ../local/imprint.html.ep templates && \
 RUN sed -i "s/qx{git describe --dirty}/'${travelynx_version}'/" lib/Travelynx/Controller/Static.pm
 RUN sed -i "s/\$self->plugin('Config');/\$self->plugin('Config'); \$self->config->{version} = '${travelynx_version}';/" lib/Travelynx.pm
 
-FROM perl:5.30-slim
+FROM docker.io/perl:5.30-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_LISTCHANGES_FRONTEND=none

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:buster-slim as files
+FROM docker.io/debian:trixie-slim as files
 
 ARG travelynx_version=git
 
@@ -18,7 +18,7 @@ RUN ln -sf ../local/imprint.html.ep templates && \
 RUN sed -i "s/qx{git describe --dirty}/'${travelynx_version}'/" lib/Travelynx/Controller/Static.pm
 RUN sed -i "s/\$self->plugin('Config');/\$self->plugin('Config'); \$self->config->{version} = '${travelynx_version}';/" lib/Travelynx.pm
 
-FROM docker.io/perl:5.30-slim
+FROM docker.io/perl:5.42-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_LISTCHANGES_FRONTEND=none
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	libdb5.3 \
 	libdb5.3-dev \
 	libpq-dev \
-	libssl1.1 \
+	libssl3t64 \
 	libssl-dev \
 	make \
 	zlib1g-dev \


### PR DESCRIPTION
Use fully qualified image names in the Dockerfile.
This is best practice and prevents errors like this:
```
[2/2] STEP 1/9: FROM perl:5.30-slim
Error: creating build container: short-name "perl:5.30-slim" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
``` 
while using podman.

Also, update image tags to newest versions