### PR TITLE
Update Hungarian locale

### DIFF
--- a/share/locales/hu_HU.po
+++ b/share/locales/hu_HU.po
@@ -270,41 +270,41 @@ msgid "changelog.2-19.1"
 msgstr "Korábbi utazások rendezése késés vagy időtartam szerint. További attribútumok is követhetik."
 
 msgid "changelog.2-19.2"
-msgstr "Enyhe vaítások a legacy IRIS backendhez: a térképadatok mostantól valamivel több esetben érhetőek el, mint korábban. Ez a backend deprecated lett és a jövőben akár törölve lehetne."
+msgstr "Enyhe javítások a legacy IRIS backendhez: a térképadatok mostantól valamivel több esetben érhetőek el, mint korábban. Ez a backend deprecated lett és a jövőben akár törölve lehetne."
 
 msgid "changelog.2-20.1"
-msgstr "“Join in” button: checkins of followees and other accounts can now be transformed into a checkin with identical data for your own account. This is only possible if your account is not already checked in."
+msgstr "„Együtt utazunk!” gomb: Ha valakivel együtt utazol akkor az ő fiókjából másolhatod a check-int, ami azt jelenti, hogy létrejön egy azonos kiindulási, célállomású és közlekedési móddal rendelkező check-in. Viszont csak akkor tudsz valakihez így csatlakozni, ha a saját fiókod jelenleg nem vagy becsekkolva."
 
 msgid "changelog.2-20.2"
-msgstr "Improved handling of backend-specific blocks and rate limits. Nevertheless, until further notice, dbris / bahn.de are only fully usable on small instances (no more than 10 concurrent checkins)."
+msgstr "A backend-specifikus blokkok és késések kezelésének javítása. Ennek ellenére a dbris/bahn.de jelenleg csak kis szervereken működik teljes mértékben (maximum 10 egyidejű check-in)."
 
 msgid "changelog.2-20.3"
-msgstr "The IRIS backend has been restored with almost all features. In many cases, it now is a viable alternative to bahn.de, at least until the end of 2026."
+msgstr "Az IRIS backend ismét teljes mértékben működőképes, szinte az összes megszokott funkcióval, és várhatóan 2026 végéig alternatívát kínál a bahn.de-vel szemben."
 
 msgid "changelog.2-21.1"
-msgstr "Statistics on past journeys are now computed immediately rather than being deferred until the corresponding detail view has been opened. History pages now load much faster."
+msgstr "A korábbi utazások statisztikáit mostantól azonnal kiszámítja a rendszer, nem csak a részletes nézet megnyitásakor. Ezenkívül a megfelelő oldalak mostantól lényegesen gyorsabban töltődnek be."
 
 msgid "changelog.2-21.2"
-msgstr "If you are running your own instance, you'll need to run 'perl index.pl stats compute-distances -m production' and 'perl index.pl stats purge-cache -m production' after the upgrade. compute-distances may take a while; it can run in the background while the travelynx web service and workers are operating normally."
+msgstr "A frissítés után azok a rendszergazdák akik saját travelynx szervert futtatnak, a következő parancsokat kell végrehajtani: 'perl index.pl stats compute-distances -m production' és 'perl index.pl stats purge-cache -m production'. Mérettől függően a compute-distances futtatása néhány perctől több óráig is eltarthat; a travelynx web-szerviz és a worker process-ek közben is normálisan futhatnak tovább."
 
 msgid "changelog.2-22.1"
-msgstr "Users can now migrate past trips across travelynx instances. Note that this requires admin rights (CLI access) on the target instance."
+msgstr "A felhasználók mostantól migrálhatják a korábbi utakat a travelynx szeverek között. Fontos megjegyezni, hogy ehhez rendszergazdai jogosultságok (CLI hozzáférés) szükségesek a célszerveren."
 
 msgid "changelog.2-22.2"
-msgstr "DBRIS / bahn.de: departure board: support DS100 / Ril100 station codes (patch by networkException)."
+msgstr "DBRIS / bahn.de: DS100/Ril100 kódok támogatása az indulásjelzőben (patchelve networkException-nek köszönhetően)."
 
 msgid "changelog.2-22.3"
-msgstr "The DBRIS / bahn.de backend is fully usable again (for now)."
+msgstr "A DBRIS / bahn.de backend ismét teljes mértékben használható (egyelőre)."
 
 # history.html.ep
 
 msgid "history.high-scores"
-msgstr "By Attribute"
+msgstr "Attribútum szerint"
 
 # history_by_year.html.ep
 
 msgid "history.review"
-msgstr "Review"
+msgstr "Évi áttekintés"
 
 # journey.html.ep
 
@@ -390,10 +390,10 @@ msgid "journey.map.upload-partial"
 msgstr "Útvonal szegmens feltöltése"
 
 msgid "journey.map.info.download"
-msgstr "JSON format: [[lon, lat, station ID], ...], with lon/lat in WGS84 coordinates. GPX files are compatible with BRouter."
+msgstr "JSON formátum: [[lon, lat, station ID], ...], ahol lon/lat a WGS84 koordinátás hosszúsági/szélességi fokok. A GPX fájlok kompatibilisek a BRouterrel."
 
 msgid "journey.map.info.upload"
-msgstr "GPX uploads must contain a single track with a single track segment (such as provided by BRouter's export). They must cover either the full route or just the travelled route segment that belongs to this checkin. Please use the appropriate upload button, otherwise chaos may ensue. There is no need to specify station IDs when uploading tracks. Note that uploads irreversibly replace previously stored map data."
+msgstr "A GPX feltöltéseknek egyetlen track-elemet kell tartalmazniuk egyetlen track szegmenssel. Egy BRouter GPX export megfelel ezeknek a követelményeknek. A feltöltéseknek tartalmazniuk kell vagy a közlekedési mód által megtett teljes útvonalat, vagy csak a check-innek megfelelő konkrét szakaszt. Feltöltéskor válaszd ki a megfelelő gombot. A station ID-t nem kell megadni a feltöltés során. Figyelem: Az egyéni térképadatok feltöltése visszavonhatatlanul törli az összes korábban tárolt térképadatokat!"
 
 msgid "journey.danger"
 msgstr "Danger Zone"
@@ -411,6 +411,9 @@ msgstr "!"
 
 msgid "landingpage.not-checked-in"
 msgstr "Jelenleg nem vagy becsekkolva"
+
+msgid "landingpage.recent-stops"
+msgstr "Legutóbbi célok"
 
 msgid "landingpage.stop-geosearch"
 msgstr "Közeledben lévő megállók keresése"
@@ -438,7 +441,7 @@ msgid "landingpage.traewelling.post"
 msgstr " volt"
 
 msgid "landingpage.features"
-msgstr "Fícsörök:" # not sure if this or rather "Feature-ök" I've seen both be used before.
+msgstr "Fícsörök:"
 
 msgid "landingpage.features.log"
 msgstr "Menetrend szerinti és valós idejű adatok naplózása. (indulási és célállomásokon)"
@@ -545,6 +548,301 @@ msgstr "A fiókokat egy év inaktivitás után e-mailben értesítjük a közelg
 msgid "register.disclaimer"
 msgstr "Kérjük, vedd figyelembe: Travelynx egy ingyenes és bármi rendelkezésre állási garacia nélküli hobbi projekt. Be nem tervezett leállások, illetve a teljes oldal hírtelen bezárása nincs tervben, de bármikor előfordulhat."
 
+# sorted_history.html.ep
+
+msgid "sorted-history.header"
+msgstr "High Score-ok"
+
+msgid "sorted-history.delay-dep"
+msgstr "Indulási késés"
+
+msgid "sorted-history.delay-arr"
+msgstr "Érkezési késés"
+
+msgid "sorted-history.sched-duration"
+msgstr "Tervezett időtartam"
+
+msgid "sorted-history.rt-duration"
+msgstr "Tényleges időtartam"
+
+msgid "sorted-history.desc"
+msgstr "Csökkenő"
+
+msgid "sorted-history.asc"
+msgstr "Növekvő"
+
+msgid "sorted-history.submit"
+msgstr "Megjelenítés"
+
+msgid "sorted-history.date"
+msgstr "Dátum"
+
+msgid "sorted-history.trip"
+msgstr "Utazás"
+
+msgid "sorted-history.delay"
+msgstr "Késés"
+
+msgid "sorted-history.duration"
+msgstr "Időtartam"
+
+# year_in_review.html.ep
+
+msgid "review.header.pre"
+msgstr " "
+
+msgid "review.header.post"
+msgstr "in Review"
+
+msgid "review.trips-stops.pre"
+msgstr "You have logged"
+
+msgid "review.trips-stops.mid"
+msgstr "across"
+
+msgid "review.trips-stops.post"
+msgstr "."
+
+msgid "review.trips"
+msgstr "trips"
+
+msgid "review.stops"
+msgstr "stops"
+
+msgid "review.trips-per-day.pre"
+msgstr "This comes down to more than"
+
+msgid "review.trips-per-day"
+msgstr "trips per day"
+
+msgid "review.trips-per-day.post"
+msgstr "!"
+
+msgid "review.travel-time.pre"
+msgstr "In total, you spent at least"
+
+msgid "review.travel-time.of-year"
+msgstr "of the entire year"
+
+msgid "review.travel-time.post"
+msgstr "in transit."
+
+msgid "review.travel-distance.pre"
+msgstr "In doing so, you traversed a total distance of approx."
+
+msgid "review.travel-distance.post"
+msgstr "."
+
+msgid "review.equivalent-circumference.pre"
+msgstr "This equals"
+
+msgid "review.equivalent-circumference.mid"
+msgstr "trips around the earth"
+
+msgid "review.equivalent-circumference.post"
+msgstr "."
+
+msgid "review.equivalent-diagonal.pre"
+msgstr "This equals"
+
+msgid "review.equivalent-diagonal.mid"
+msgstr "journeys to the centre of the earth and back"
+
+msgid "review.equivalent-diagonal.post"
+msgstr "."
+
+msgid "review.next-page"
+msgstr "Swip here or click below for next page"
+
+msgid "review.mean-trip.header"
+msgstr "An average Trip"
+
+msgid "review.mean-trip-3.pre"
+msgstr "… meant taking"
+
+msgid "review.mean-trip-3.mid"
+msgstr "within the"
+
+msgid "review.mean-trip-3.post"
+msgstr " triangle."
+
+msgid "review.mean-trip-2.pre"
+msgstr "… was always along your commute between"
+
+msgid "review.mean-trip-2.mid"
+msgstr "and"
+
+msgid "review.mean-trip-2.post"
+msgstr "."
+
+msgid "review.time-distance.pre"
+msgstr "On average, it took"
+
+msgid "review.time-distance.mid"
+msgstr "to cover approx."
+
+msgid "review.time-distance.post"
+msgstr "."
+
+msgid "review.on-time"
+msgstr "It was consistently <strong>on time</strong>. Impressive!"
+
+msgid "review.delay-decreasing.pre"
+msgstr "It departed"
+
+msgid "review.delay-decreasing.mid"
+msgstr "later than scheduled, but managed to partially make up for that. When reaching its destination, it was delayed by only"
+
+msgid "review.delay-decreasing.post"
+msgstr "."
+
+msgid "review.delay-constant.pre"
+msgstr "It departured"
+
+msgid "review.delay-constant.post"
+msgstr " too late and arrived with the same delay."
+
+msgid "review.delay-increasing.pre"
+msgstr "It departed with a delay of"
+
+msgid "review.delay-increasing.mid"
+msgstr "and increased it to"
+
+msgid "review.delay-increasing.post"
+msgstr " at the destination."
+
+msgid "review.high-scores.header"
+msgstr "High Scores"
+
+msgid "review.high-scores.with"
+msgstr "with"
+
+msgid "review.high-scores.from"
+msgstr "from"
+
+msgid "review.high-scores.to"
+msgstr "to"
+
+msgid "review.high-scores.longest-trip.link"
+msgstr "Longest Leg"
+
+msgid "review.high-scores.longest-trip.pre"
+msgstr " "
+
+msgid "review.high-scores.longest-trip.post"
+msgstr "."
+
+msgid "review.high-scores.farthest-trip-eq-longest.pre"
+msgstr "With a distance of"
+
+msgid "review.high-scores.farthest-trip-eq-longest.post"
+msgstr ", it also was your longest leap."
+
+msgid "review.high-scores.farthest-trip.link"
+msgstr "Longest Leap"
+
+msgid "review.high-scores.farthest-trip.pre"
+msgstr " "
+
+msgid "review.high-scores.farthest-trip.post"
+msgstr "."
+
+msgid "review.high-scores.shortest-trip.link"
+msgstr "Tiniest Trip"
+
+msgid "review.high-scores.shortest-trip.pre"
+msgstr " "
+
+msgid "review.high-scores.shortest-trip.post"
+msgstr "."
+
+msgid "review.high-scores.closest-trip-eq-shortest.pre"
+msgstr "With a distance of"
+
+msgid "review.high-scores.closest-trip-eq-shortest.post"
+msgstr ", it was also your closest checkin / checkout couple."
+
+msgid "review.high-scores.closest-trip.link"
+msgstr "Closest Checkout"
+
+msgid "review.high-scores.closest-trip.pre"
+msgstr " "
+
+msgid "review.high-scores.closest-trip.post"
+msgstr "."
+
+msgid "review.annotated-percent.pre"
+msgstr " "
+
+msgid "review.annotated-percent.post"
+msgstr " of all trips came with remarks related to delays or disruptions."
+
+msgid "review.top-annotations"
+msgstr "Most frequent remarks:"
+
+msgid "review.punctual-percent.pre"
+msgstr "Merely"
+
+msgid "review.punctual-percent.post"
+msgstr " of all trips were right on schedule."
+
+msgid "review.hour-delay-percent.pre"
+msgstr " "
+
+msgid "review.hour-delay-percent.post"
+msgstr " of your trips were delayed by at least an hour"
+
+msgid "review.and-cancelled-percent.pre"
+msgstr "and"
+
+msgid "review.and-cancelled-percent.post"
+msgstr " did not even make it to your destination."
+
+msgid "review.cancelled-percent.pre"
+msgstr " "
+
+msgid "review.cancelled-percent.post"
+msgstr " of your trips were cancelled."
+
+msgid "review.most-delayed.pre"
+msgstr "With"
+
+msgid "review.most-delayed.mid"
+msgstr ", "
+
+msgid "review.most-delayed.post"
+msgstr " effortlessly took the first place."
+
+msgid "review.most-delay.pre"
+msgstr "The trip with"
+
+msgid "review.most-delay.from"
+msgstr "from"
+
+msgid "review.most-delay.to"
+msgstr "to"
+
+msgid "review.most-delay.mid"
+msgstr "was super serene: it took"
+
+msgid "review.most-delay.post"
+msgstr " longer than scheduled."
+
+msgid "review.most-undelay.pre"
+msgstr "On the other hand,"
+
+msgid "review.most-undelay.from"
+msgstr "took the handle to the table and managed to go from"
+
+msgid "review.most-undelay.to"
+msgstr "to"
+
+msgid "review.most-undelay.mid"
+msgstr " an impressive"
+
+msgid "review.most-undelay.post"
+msgstr " faster than anticipated."
+
 # _checked_in.html.ep, _public_status_card.html.ep
 
 msgid "status.is-checked-in"
@@ -648,7 +946,7 @@ msgstr "Láthatóság"
 
 #, shown once check-in is completed
 msgid "status.undo-checkin"
-msgstr "Becsekkelés visszavonása"
+msgstr "Check-in visszavonása"
 
 msgid "status.force-checkout-lead"
 msgstr "Körülbelül tíz perccel az érkezés után automatikusan kicsekkolódsz. Ha a backend leállt, vagy az utazás más okokból elveszlett:"

--- a/share/locales/hu_HU.po
+++ b/share/locales/hu_HU.po
@@ -46,6 +46,43 @@ msgid "header.error"
 msgstr "Hiba"
 
 #
+# LT (localized duration)
+#
+
+msgid "LT.weeks"
+msgstr "hét"
+
+msgid "LT.week"
+msgstr "hét"
+
+msgid "LT.days"
+msgstr "nap"
+
+msgid "LT.day"
+msgstr "nap"
+
+msgid "LT.hours"
+msgstr "óra"
+
+msgid "LT.hour"
+msgstr "óra"
+
+msgid "LT.minutes"
+msgstr "perc"
+
+msgid "LT.minute"
+msgstr "perc"
+
+msgid "LT.zero-minutes"
+msgstr "0 perc"
+
+msgid "LT.final-and"
+msgstr ", és"
+
+msgid "LT.and"
+msgstr " és"
+
+#
 # Templates
 #
 
@@ -188,6 +225,24 @@ msgstr "követési kérések"
 msgid "account.interaction.disabled"
 msgstr "Senki sem követhet"
 
+msgid "account.profile"
+msgstr "Nyílvános profiloldalad"
+
+msgid "account.interaction.requests"
+msgstr "Követési kérések"
+
+msgid "account.interaction.requests.incoming.none"
+msgstr "nincs beérkező kérés"
+
+msgid "account.interaction.requests.incoming.some"
+msgstr "beérkező kérés"
+
+msgid "account.interaction.requests.outgoing.none"
+msgstr "nincs kimenő kérés"
+
+msgid "account.interaction.requests.outgoing.some"
+msgstr "kimenő kérés"
+
 # changelog.html.ep
 
 msgid "changelog.added"
@@ -201,6 +256,55 @@ msgstr "Lokalizáció. A travelynx most már angolul, részben pedig franciául,
 
 msgid "changelog.2-16.2"
 msgstr "A távolságszámítás és a gyűrűsvonali utazások megjelenítése javítva lett. Az előzménytérképen megjelenített utazások még mindig részben hibásak."
+
+msgid "changelog.2-17.1"
+msgstr "Az egyes utak térképadatai („Polylines”) mostantól GPX formátumban exportálhatók és importálhatók. Ez lehetővé teszi a térképadatok utólagos javítását vagy kiegészítését. A GPX import/export kompatibilis a BRouter-Web programmal."
+
+msgid "changelog.2-18.1"
+msgstr "A becsekellés és az átszállási javaslatok ismét működnek a DBRIS, EFA és IRIS backendeknél. A HAFAS backendből hiányoznak a szükséges indulásjelző adatok. Előfordulhat, hogy a MOTIS backendekből is hiányoznak a szükséges adatok."
+
+msgid "changelog.2-18.2"
+msgstr "Az előzményekben a teljes távolság kiszámításánál most már azokat az utakat is vesz figyelembe, amelyekhez nem állnak rendelkezésre megfelelő útvonaladatok (azaz ahol csak légvonalban mért távolság / légvonalban mért távolság áll rendelkezésre). A mostani verzió előtt az ilyen utakat ki lettek hagyva a havi és éves statisztikák kiszámításakor."
+
+msgid "changelog.2-19.1"
+msgstr "Korábbi utazások rendezése késés vagy időtartam szerint. További attribútumok is követhetik."
+
+msgid "changelog.2-19.2"
+msgstr "Enyhe vaítások a legacy IRIS backendhez: a térképadatok mostantól valamivel több esetben érhetőek el, mint korábban. Ez a backend deprecated lett és a jövőben akár törölve lehetne."
+
+msgid "changelog.2-20.1"
+msgstr "“Join in” button: checkins of followees and other accounts can now be transformed into a checkin with identical data for your own account. This is only possible if your account is not already checked in."
+
+msgid "changelog.2-20.2"
+msgstr "Improved handling of backend-specific blocks and rate limits. Nevertheless, until further notice, dbris / bahn.de are only fully usable on small instances (no more than 10 concurrent checkins)."
+
+msgid "changelog.2-20.3"
+msgstr "The IRIS backend has been restored with almost all features. In many cases, it now is a viable alternative to bahn.de, at least until the end of 2026."
+
+msgid "changelog.2-21.1"
+msgstr "Statistics on past journeys are now computed immediately rather than being deferred until the corresponding detail view has been opened. History pages now load much faster."
+
+msgid "changelog.2-21.2"
+msgstr "If you are running your own instance, you'll need to run 'perl index.pl stats compute-distances -m production' and 'perl index.pl stats purge-cache -m production' after the upgrade. compute-distances may take a while; it can run in the background while the travelynx web service and workers are operating normally."
+
+msgid "changelog.2-22.1"
+msgstr "Users can now migrate past trips across travelynx instances. Note that this requires admin rights (CLI access) on the target instance."
+
+msgid "changelog.2-22.2"
+msgstr "DBRIS / bahn.de: departure board: support DS100 / Ril100 station codes (patch by networkException)."
+
+msgid "changelog.2-22.3"
+msgstr "The DBRIS / bahn.de backend is fully usable again (for now)."
+
+# history.html.ep
+
+msgid "history.high-scores"
+msgstr "By Attribute"
+
+# history_by_year.html.ep
+
+msgid "history.review"
+msgstr "Review"
 
 # journey.html.ep
 
@@ -269,6 +373,30 @@ msgstr "Exportálás"
 
 msgid "journey.edit"
 msgstr "Szerkesztés"
+
+msgid "journey.map-data"
+msgstr "Térképadatok"
+
+msgid "journey.map.download"
+msgstr "Letöltés"
+
+msgid "journey.map.upload"
+msgstr "Feltöltés"
+
+msgid "journey.map.upload-full"
+msgstr "Teljes útvonal feltöltése"
+
+msgid "journey.map.upload-partial"
+msgstr "Útvonal szegmens feltöltése"
+
+msgid "journey.map.info.download"
+msgstr "JSON format: [[lon, lat, station ID], ...], with lon/lat in WGS84 coordinates. GPX files are compatible with BRouter."
+
+msgid "journey.map.info.upload"
+msgstr "GPX uploads must contain a single track with a single track segment (such as provided by BRouter's export). They must cover either the full route or just the travelled route segment that belongs to this checkin. Please use the appropriate upload button, otherwise chaos may ensue. There is no need to specify station IDs when uploading tracks. Note that uploads irreversibly replace previously stored map data."
+
+msgid "journey.danger"
+msgstr "Danger Zone"
 
 msgid "journey.delete"
 msgstr "Törlés"

--- a/share/locales/reference.md
+++ b/share/locales/reference.md
@@ -3,7 +3,7 @@
 * de-DE: 100.0% complete (0 missing)
 * en-GB: 100.0% complete (0 missing)
 * fr-FR: 97.1% complete (9 missing)
-* hu-HU: 52.1% complete (150 missing)
+* hu-HU: 52.1% complete (123 missing)
 * pl-PL: 98.4% complete (5 missing)
 
 ### 
@@ -139,7 +139,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Wochen
 * en-GB: weeks
 * fr-FR: semaines
-* hu-HU *missing*
+* hu-HU: hét
 * pl-PL: tygodni
 
 ### LT.week
@@ -147,7 +147,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Woche
 * en-GB: week
 * fr-FR: semaine
-* hu-HU *missing*
+* hu-HU: hét
 * pl-PL: tydzień
 
 ### LT.days
@@ -155,7 +155,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Tage
 * en-GB: days
 * fr-FR: jours
-* hu-HU *missing*
+* hu-HU: nap
 * pl-PL: dni
 
 ### LT.day
@@ -163,7 +163,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Tag
 * en-GB: day
 * fr-FR: jour
-* hu-HU *missing*
+* hu-HU: nap
 * pl-PL: dzień
 
 ### LT.hours
@@ -171,7 +171,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Stunden
 * en-GB: hours
 * fr-FR: heures
-* hu-HU *missing*
+* hu-HU: óra
 * pl-PL: godzin
 
 ### LT.hour
@@ -179,7 +179,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Stunde
 * en-GB: hour
 * fr-FR: heure
-* hu-HU *missing*
+* hu-HU: óra
 * pl-PL: godzina
 
 ### LT.minutes
@@ -187,7 +187,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Minuten
 * en-GB: minutes
 * fr-FR: minutes
-* hu-HU *missing*
+* hu-HU: perc
 * pl-PL: minut
 
 ### LT.minute
@@ -195,7 +195,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Minute
 * en-GB: minute
 * fr-FR: minute
-* hu-HU *missing*
+* hu-HU: perc
 * pl-PL: minuta
 
 ### LT.zero-minutes
@@ -203,7 +203,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: 0 Minuten
 * en-GB: 0 minutes
 * fr-FR: 0 minutes
-* hu-HU *missing*
+* hu-HU: 0 perc
 * pl-PL: 0 minut
 
 ### LT.final-and
@@ -211,7 +211,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE:  und
 * en-GB: , and
 * fr-FR: , et
-* hu-HU *missing*
+* hu-HU: , és
 * pl-PL:  i
 
 ### LT.and
@@ -219,7 +219,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE:  und
 * en-GB:  and
 * fr-FR:  et
-* hu-HU *missing*
+* hu-HU: és
 * pl-PL:  i
 
 ## Templates
@@ -593,7 +593,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Öffentliches Profil
 * en-GB: Public profile page
 * fr-FR: Page de profil publique
-* hu-HU *missing*
+* hu-HU: Nyílvános profiloldalad
 * pl-PL: Profil publiczny
 
 ### account.interaction.requests
@@ -601,7 +601,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Offene anfragen
 * en-GB: Pending requests
 * fr-FR: requêtes en attente
-* hu-HU *missing*
+* hu-HU: Követési kérések
 * pl-PL: Otwarte zapytania
 
 ### account.interaction.requests.incoming.none
@@ -609,7 +609,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: keine eingehend
 * en-GB: none incoming
 * fr-FR: aucune entrante
-* hu-HU *missing*
+* hu-HU: nincs beérkező kérés
 * pl-PL: brak przychodzących
 
 ### account.interaction.requests.incoming.some
@@ -617,7 +617,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: eingehend
 * en-GB: incoming
 * fr-FR: entrantes
-* hu-HU *missing*
+* hu-HU: beérkező kérés
 * pl-PL: przychodzące
 
 ### account.interaction.requests.outgoing.none
@@ -625,7 +625,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: keine ausgehend
 * en-GB: none outgoing
 * fr-FR: aucune sortante
-* hu-HU *missing*
+* hu-HU: nincs kimenő kérés
 * pl-PL: brak wychodzących
 
 ### account.interaction.requests.outgoing.some
@@ -633,7 +633,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: ausgehend
 * en-GB: outgoing
 * fr-FR: sortantes
-* hu-HU *missing*
+* hu-HU: kimenő kérés
 * pl-PL: wychodzące
 
 ## changelog.html.ep
@@ -683,7 +683,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Checkin- und Verbindungsvorschläge sind für DBRIS-, EFA- und IRIS-Backends wieder verfügbar. Bei HAFAS-Backends fehlen die dazu notwendigen Daten in der Abfahrtstafel. Bei MOTIS-Backends fehlen die Daten möglicherweise ebenfalls.
 * en-GB: Checkin and connection suggestions are now available again for DBRIS, EFA, and IRIS backends. HAFAS backends lack the required station board data. MOTIS backends may lack the required data as well.
 * fr-FR: L'enregistrement et les suggestions de correspondances sont maintenant disponibles à nouveau pour les backends DBRIS, EFA et IRIS. Les backends HAFAS n'ont pas les données de tableau de station requises. Les backends MOTIS backends peuvent également ne pas avoir ces données.
-* hu-HU *missing*
+* hu-HU: A becsekellés és az átszállási javaslatok ismét működnek a DBRIS, EFA és IRIS backendeknél. A HAFAS backendből hiányoznak a szükséges indulásjelző adatok. Előfordulhat, hogy a MOTIS backendekből is hiányoznak a szükséges adatok.
 * pl-PL: Propozycje check-inów i połączen są znów dostępne dla backendów DBRIS, EFA i IRIS. W przypadku backendów HAFAS brakuje potrzebnych danych w tabeli odjazdów. W przypadku backendów MOTIS dane też mogą być niedostępne.
 
 ### changelog.2-18.2
@@ -691,7 +691,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Bei der Reisestreckenberechnung für vergangene Fahrten werden nun auch Fahrten mit ungenügender Datenlage (d.h. bei denen ausschließlich die Entfernung nach Luftlinie verfügbar ist) berücksichtigt. Bislang wurden diese für monatliche und jährliche Statistiken ignoriert.
 * en-GB: Total distance calculation in the history now includes trips that lack appropriate route data (i.e., where only beeline distance / distance as the crow flies is available). Before this release, such trips were ignored when computing monthly and yearly statistics.
 * fr-FR: Le calcul de la distance totale dans l'historique inclut maintenant les voyages qui n'ont pas les données de trajet appropriées (par exemple où seule la distance à vol d'oiseau est disponible). Avant cette version, de tels trajets étaient ignorés lors du calcul des statistiques mensuelles et annuelles
-* hu-HU *missing*
+* hu-HU: Az előzményekben a teljes távolság kiszámításánál most már azokat az utakat is vesz figyelembe, amelyekhez nem állnak rendelkezésre megfelelő útvonaladatok (azaz ahol csak légvonalban mért távolság / légvonalban mért távolság áll rendelkezésre). A mostani verzió előtt az ilyen utakat ki lettek hagyva a havi és éves statisztikák kiszámításakor.
 * pl-PL: Przy obliczaniu tras podróży dla przejazdów z przeszłości uwzględniane są teraz również przejazdy z niewystarczającymi danymi (czyli te, dla których dostępna jest wyłącznie odległość w linii prostej). Do tej pory były one pomijane w statystykach miesięcznych i rocznych.
 
 ### changelog.2-19.1
@@ -699,7 +699,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Sortierung vergangener Fahrten nach Verspätung oder Dauer. Weitere Attribute folgen ggf.
 * en-GB: High score of all past checkins sorted by delay or duration. More attributes may follow.
 * fr-FR: Meilleurs scores de tous les enregistrements passés triés par retard ou durée. Plus d'attributs pourraient suivre.
-* hu-HU *missing*
+* hu-HU: Korábbi utazások rendezése késés vagy időtartam szerint. További attribútumok is követhetik.
 * pl-PL: Sortowanie poprzednich przejazdów według opóźnienia lub czasu trwania. W razie możliwości dodane zostaną kolejne atrybuty.
 
 ### changelog.2-19.2
@@ -707,7 +707,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: IRIS-Backend: Geringfügige Verbesserung der Verfügbarkeit von Kartendaten. Das Backend ist weiterhin abgekündigt und kann jederzeit entfallen.
 * en-GB: Minor life support adjustments for the legacy IRIS backend: map data should now be available in slightly more cases than before.
 * fr-FR: Ajustements mineurs de durée de vie pour le backend historique IRIS : les données de carte devraient être maintenant disponibles dans quelques cas supplémentaires par rapport à précédemment.
-* hu-HU *missing*
+* hu-HU: Enyhe vaítások a legacy IRIS backendhez: a térképadatok mostantól valamivel több esetben érhetőek el, mint korábban. Ez a backend deprecated lett és a jövőben akár törölve lehetne.
 * pl-PL: Backend IRIS: Nieznaczna poprawa dostępności danych mapowych. Backend nadal jest wypowiedziany i może zostać wycofany w dowolnym momencie.
 
 ## history.html.ep
@@ -905,7 +905,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Kartendaten
 * en-GB: Map Data
 * fr-FR: Données de carte
-* hu-HU *missing*
+* hu-HU: Térképadatok
 * pl-PL: Dane mapy
 
 ### journey.map.download
@@ -913,7 +913,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Herunterladen
 * en-GB: Download
 * fr-FR: Télécharger
-* hu-HU *missing*
+* hu-HU: Letöltés
 * pl-PL: Pobierz
 
 ### journey.map.upload
@@ -921,7 +921,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Hochladen
 * en-GB: Upload
 * fr-FR: Téléverser
-* hu-HU *missing*
+* hu-HU: Feltöltés
 * pl-PL: Prześlij
 
 ### journey.map.upload-full
@@ -929,7 +929,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Komplette Route
 * en-GB: Upload full route
 * fr-FR: Téléverser tout l'itinéraire
-* hu-HU *missing*
+* hu-HU: Teljes útvonal feltöltése
 * pl-PL: Cała trasa
 
 ### journey.map.upload-partial
@@ -937,7 +937,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Gefahrenes Segment
 * en-GB: Upload travelled segment
 * fr-FR: Téléverser une partie de l'itinéraire
-* hu-HU *missing*
+* hu-HU: Útvonal szegmens feltöltése
 * pl-PL: Przejechany odcinek
 
 ### journey.map.info.download

--- a/share/locales/reference.md
+++ b/share/locales/reference.md
@@ -3,7 +3,7 @@
 * de-DE: 100.0% complete (0 missing)
 * en-GB: 100.0% complete (0 missing)
 * fr-FR: 97.1% complete (9 missing)
-* hu-HU: 52.1% complete (123 missing)
+* hu-HU: 52.1% complete (104 missing)
 * pl-PL: 98.4% complete (5 missing)
 
 ### 
@@ -675,7 +675,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Kartendaten („Polylines“) zu einzelnen Fahrten können nun als GPX ex- und importiert werden. Somit können Kartendaten nachträglich korrigiert oder nachgepflegt werden. Das GPX-Datenformat ist mit BRouter-Web kompatibel.
 * en-GB: Map data (“polylines”) for individual trips can now be exported and imported in the GPX format. This allows map data to be corrected or augmented after the fact. The GPX import/export is compatible with BRouter-Web.
 * fr-FR: Les données de carte ("Polylines") des trajets individuels peuvent maintenant être exportées et importées au format GPX. Cela permet de corriger ou compléter les données de carte a posteriori. Les imports/exports GPX sont compatibles avec BRouter-Web.
-* hu-HU *missing*
+* hu-HU: Az egyes utak térképadatai („Polylines”) mostantól GPX formátumban exportálhatók és importálhatók. Ez lehetővé teszi a térképadatok utólagos javítását vagy kiegészítését. A GPX import/export kompatibilis a BRouter-Web programmal.
 * pl-PL: Dane mapy („Polylines”) dla pojedynczych przejazdów można teraz eksportować i importować jako pliki GPX. Dzięki temu dane mapy można później poprawić lub uzupełnić. Format danych GPX jest kompatybilny z BRouter-Web.
 
 ### changelog.2-18.1
@@ -707,7 +707,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: IRIS-Backend: Geringfügige Verbesserung der Verfügbarkeit von Kartendaten. Das Backend ist weiterhin abgekündigt und kann jederzeit entfallen.
 * en-GB: Minor life support adjustments for the legacy IRIS backend: map data should now be available in slightly more cases than before.
 * fr-FR: Ajustements mineurs de durée de vie pour le backend historique IRIS : les données de carte devraient être maintenant disponibles dans quelques cas supplémentaires par rapport à précédemment.
-* hu-HU: Enyhe vaítások a legacy IRIS backendhez: a térképadatok mostantól valamivel több esetben érhetőek el, mint korábban. Ez a backend deprecated lett és a jövőben akár törölve lehetne.
+* hu-HU: Enyhe javítások a legacy IRIS backendhez: a térképadatok mostantól valamivel több esetben érhetőek el, mint korábban. Ez a backend deprecated lett és a jövőben akár törölve lehetne.
 * pl-PL: Backend IRIS: Nieznaczna poprawa dostępności danych mapowych. Backend nadal jest wypowiedziany i może zostać wycofany w dowolnym momencie.
 
 ## history.html.ep
@@ -717,7 +717,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Nach Eigenschaft
 * en-GB: By Attribute
 * fr-FR: Par attribut
-* hu-HU *missing*
+* hu-HU: Attribútum szerint
 * pl-PL: Według kryteriów
 
 ## history_by_year.html.ep
@@ -727,7 +727,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Rückblick
 * en-GB: Review
 * fr-FR: Résumé
-* hu-HU *missing*
+* hu-HU: Évi áttekintés
 * pl-PL: Podsumowanie
 
 ## journey.html.ep
@@ -945,7 +945,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: JSON-Format: [[lon, lat, ID], ...] in WGS84-Koordinaten. GPX-Dateien sind mit BRouter kompatibel.
 * en-GB: JSON format: [[lon, lat, station ID], ...], with lon/lat in WGS84 coordinates. GPX files are compatible with BRouter.
 * fr-FR: Format JSON : [[lon, lat, station ID], ...], avec latitude/longitude en coordonnées WGS84. Les fichiers GPX files sont compatibles avec BRouter.
-* hu-HU *missing*
+* hu-HU: JSON formátum: [[lon, lat, station ID], ...], ahol lon/lat a WGS84 koordinátás hosszúsági/szélességi fokok. A GPX fájlok kompatibilisek a BRouterrel.
 * pl-PL: Format JSON: [[lon, lat, ID], ...] w współrzędnych WGS84. Pliki GPX są kompatybilne z BRouter.
 
 ### journey.map.info.upload
@@ -953,7 +953,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: GPX-Uploads müssen ein einzelnes track-Element mit einem einzelnen track segment enthalten. Ein BRouter-GPX-Export erfüllt diese Vorgaben. Uploads müssen entweder die komplette Route des Verkehrsmittels oder nur den zu diesem Checkin zugehörigen Abschnitt enthalten. Beim Hochladen bitte die passende Schaltfläche auswählen. IDs von Halten müssen beim Upload nicht angegeben werden. Bitte beachten: Beim Einspielen eigener Kartendaten werden die zuvor gespeicherten unwiderruflich gelöscht.
 * en-GB: GPX uploads must contain a single track with a single track segment (such as provided by BRouter's export). They must cover either the full route or just the travelled route segment that belongs to this checkin. Please use the appropriate upload button, otherwise chaos may ensue. There is no need to specify station IDs when uploading tracks. Note that uploads irreversibly replace previously stored map data.
 * fr-FR: Les téléversements GPX doivent contenir une seule trace avec un seul segment de trace (comme fourni par l'export BRouter). Ils doivent couvrir soit l'itinéraire entier, soit uniquement le segment du trajet qui correspond à l'enregistrement. Merci d'utiliser le bouton de téléversement approprié, sinon cela pourrait échouer. Il n'y a pas besoin de spécifier un ID de station lors de l'envoi des pistes. Il faut noter que les téléversements remplacent de manière irréversible les données de carte précédemment stockées.
-* hu-HU *missing*
+* hu-HU: A GPX feltöltéseknek egyetlen track-elemet kell tartalmazniuk egyetlen track szegmenssel. Egy BRouter GPX export megfelel ezeknek a követelményeknek. A feltöltéseknek tartalmazniuk kell vagy a közlekedési mód által megtett teljes útvonalat, vagy csak a check-innek megfelelő konkrét szakaszt. Feltöltéskor válaszd ki a megfelelő gombot. A station ID-t nem kell megadni a feltöltés során. Figyelem: Az egyéni térképadatok feltöltése visszavonhatatlanul törli az összes korábban tárolt térképadatokat!
 * pl-PL: Pliki GPX muszą zawierać jeden element track z jednym segmentem track. Eksport GPX z BRouter spełnia te wymagania. Przesyłane dane muszą zawierać całą trasę środka transportu lub tylko odcinek odpowiadający temu checkinowi. Przy przesyłaniu wybierz odpowiedni przycisk. ID przystanków nie muszą być podane. Uwaga: przesłanie własnych danych mapy bezpowrotnie usuwa wcześniej zapisane dane.
 
 ### journey.danger
@@ -961,7 +961,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Danger Zone
 * en-GB: Danger Zone
 * fr-FR: Zone de danger
-* hu-HU *missing*
+* hu-HU: Danger Zone
 * pl-PL: Danger Zone
 
 ### journey.delete
@@ -1003,7 +1003,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Letzte Ziele
 * en-GB: Latest destinations
 * fr-FR: Dernières destinations
-* hu-HU *missing*
+* hu-HU: Legutóbbi célok
 * pl-PL: Ostatnie cele podróży
 
 ### landingpage.stop-geosearch
@@ -1077,7 +1077,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Features:
 * en-GB: Features:
 * fr-FR: Fonctionnalités :
-* hu-HU *missing*
+* hu-HU: Fícsörök:
 * pl-PL: Funkcje:
 
 ### landingpage.features.log
@@ -1357,7 +1357,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: High Scores
 * en-GB: High Scores
 * fr-FR: Meilleurs Scores
-* hu-HU *missing*
+* hu-HU: High Score-ok
 * pl-PL: Najlepsze wyniki
 
 ### sorted-history.delay-dep
@@ -1365,7 +1365,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Verspätung bei Abfahrt
 * en-GB: Departure Delay
 * fr-FR: Retard au départ
-* hu-HU *missing*
+* hu-HU: Indulási késés
 * pl-PL: Opóźnienie odjazdu
 
 ### sorted-history.delay-arr
@@ -1373,7 +1373,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Verspätung bei Ankunft
 * en-GB: Arrival Delay
 * fr-FR: Retard à l'arrivée
-* hu-HU *missing*
+* hu-HU: Érkezési késés
 * pl-PL: Opóźnienie przy przyjeździe
 
 ### sorted-history.sched-duration
@@ -1381,7 +1381,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Geplante Dauer
 * en-GB: Scheduled Duration
 * fr-FR: Durée prévue
-* hu-HU *missing*
+* hu-HU: Tervezett időtartam
 * pl-PL: Planowany czas trwania
 
 ### sorted-history.rt-duration
@@ -1389,7 +1389,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Tatsächliche Dauer
 * en-GB: Actual Duration
 * fr-FR: Durée réelle
-* hu-HU *missing*
+* hu-HU: Tényleges időtartam
 * pl-PL: Rzeczywisty czas trwania
 
 ### sorted-history.desc
@@ -1397,7 +1397,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Absteigend
 * en-GB: Descending
 * fr-FR: Descendant
-* hu-HU *missing*
+* hu-HU: Csökkenő
 * pl-PL: Malejąco
 
 ### sorted-history.asc
@@ -1405,7 +1405,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Aufsteigend
 * en-GB: Ascending
 * fr-FR: Ascendant
-* hu-HU *missing*
+* hu-HU: Növekvő
 * pl-PL: Rosnąco
 
 ### sorted-history.submit
@@ -1413,7 +1413,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Anzeigen
 * en-GB: Show
 * fr-FR: Afficher
-* hu-HU *missing*
+* hu-HU: Megjelenítés
 * pl-PL: Wyświetl
 
 ### sorted-history.date
@@ -1421,7 +1421,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Datum
 * en-GB: Date
 * fr-FR: Date
-* hu-HU *missing*
+* hu-HU: Dátum
 * pl-PL: Data
 
 ### sorted-history.trip
@@ -1429,7 +1429,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Fahrt
 * en-GB: Trip
 * fr-FR: Voyage
-* hu-HU *missing*
+* hu-HU: Utazás
 * pl-PL: Podróż
 
 ### sorted-history.delay
@@ -1437,7 +1437,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Verspätung
 * en-GB: Delay
 * fr-FR: Retard
-* hu-HU *missing*
+* hu-HU: Késés
 * pl-PL: Opóźnienie
 
 ### sorted-history.duration
@@ -1445,7 +1445,7 @@ Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 && (n<10 || n>=20) ? 1
 * de-DE: Dauer
 * en-GB: Duration
 * fr-FR: Durée
-* hu-HU *missing*
+* hu-HU: Időtartam
 * pl-PL: Czas
 
 ## year_in_review.html.ep


### PR DESCRIPTION
Well, that was a lot that I missed over the last year, but it should all be up to date now! Also some smaller changes to reference.md and a duplicate entry in de_DE.po (`review.high-scores.farthest-trip.link`, though apparently I missed the one in pl_PL.po, but they're both different translations??? someone would need to decide which one to keep there :sweat_smile:).

Probably not every translation will sound perfect, but then again, perfect translations with Hungarian would require so many different systems like detecting vowel harmony for station names and train types to give them suitable suffixes, that would 100% be out of scope either way. :sweat_smile: 

Lemme know if there's something I need to change.

Cheers,
Aurora